### PR TITLE
Added collection search extension

### DIFF
--- a/stac_fastapi/api/stac_fastapi/api/config.py
+++ b/stac_fastapi/api/stac_fastapi/api/config.py
@@ -23,3 +23,4 @@ class AddOns(enum.Enum):
     """Enumeration of available third party add ons."""
 
     bulk_transaction = "bulk-transaction"
+    collection_search = "collection-search"

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/__init__.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/__init__.py
@@ -6,6 +6,7 @@ from .pagination import PaginationExtension, TokenPaginationExtension
 from .query import QueryExtension
 from .sort import SortExtension
 from .transaction import TransactionExtension
+from .collectionSearch import CollectionSearchExtension
 
 __all__ = (
     "ContextExtension",
@@ -16,4 +17,5 @@ __all__ = (
     "SortExtension",
     "TokenPaginationExtension",
     "TransactionExtension",
+    "CollectionSearchExtension",
 )

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/collectionSearch/__init__.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/collectionSearch/__init__.py
@@ -1,0 +1,6 @@
+"""Filter extension module."""
+
+
+from .collectionSearch import CollectionSearchExtension
+
+__all__ = ["CollectionSearchExtension"]

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/collectionSearch/collectionSearch.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/collectionSearch/collectionSearch.py
@@ -1,0 +1,109 @@
+# encoding: utf-8
+"""Collection Search Extension."""
+from enum import Enum
+from typing import List, Type, Union
+
+import attr
+from fastapi import APIRouter, FastAPI
+from starlette.responses import Response
+from stac_pydantic.api.collections import Collections
+
+from stac_fastapi.api.models import JSONSchemaResponse
+from stac_fastapi.api.routes import create_async_endpoint
+from stac_fastapi.types.core import AsyncCollectionSearchClient, CollectionSearchClient
+from stac_fastapi.types.extension import ApiExtension
+from stac_fastapi.types.search import BaseCollectionSearchGetRequest, BaseCollectionSearchPostRequest
+
+from .request import CollectionSearchExtensionGetRequest, CollectionSearchExtensionPostRequest
+
+class CollectionSearchConformanceClasses(str, Enum):
+    """Conformance classes for the Collection Search extension.
+
+    See
+    https://github.com/stac-api-extensions/collection-search
+    """
+
+    CORE = "https://api.stacspec.org/v1.0.0-rc.1/core"
+    COLLECTION_SEARCH = "https://api.stacspec.org/v1.0.0-rc.1/collection-search"
+    SIMPLE_QUERY = "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/simple-query"
+
+@attr.s
+class CollectionSearchExtension(ApiExtension):
+    """CollectionSearch Extension.
+
+    The collection search extension adds two endpoints which allow searching of 
+    collections via GET and POST:
+        GET /collection-search
+        POST /collection-search
+
+    https://github.com/stac-api-extensions/collection-search
+
+    Attributes:
+        search_get_request_model: Get request model for collection search
+        search_post_request_model: Post request model for collection search
+        client: Collection Search endpoint logic
+        conformance_classes: Conformance classes provided by the extension
+    """
+    
+    GET = CollectionSearchExtensionGetRequest
+    POST = CollectionSearchExtensionPostRequest
+
+    collection_search_get_request_model: Type[BaseCollectionSearchGetRequest] = attr.ib(
+        default=BaseCollectionSearchGetRequest
+    )
+    collection_search_post_request_model: Type[BaseCollectionSearchPostRequest] = attr.ib(
+        default=BaseCollectionSearchPostRequest
+    )
+    
+    client: Union[AsyncCollectionSearchClient, CollectionSearchClient] = attr.ib(
+        factory=CollectionSearchClient
+    )
+    
+    conformance_classes: List[str] = attr.ib(
+        default=[
+            CollectionSearchConformanceClasses.CORE,
+            CollectionSearchConformanceClasses.COLLECTION_SEARCH,
+            CollectionSearchConformanceClasses.SIMPLE_QUERY,
+        ]
+    )
+    router: APIRouter = attr.ib(factory=APIRouter)
+    response_class: Type[Response] = attr.ib(default=JSONSchemaResponse)
+    
+
+    def register(self, app: FastAPI) -> None:
+        """Register the extension with a FastAPI application.
+
+        Args:
+            app: target FastAPI application.
+
+        Returns:
+            None
+        """
+        self.router.prefix = app.state.router_prefix
+        self.router.add_api_route(
+            name="Collection Search",
+            path="/collection-search",
+            response_model=Collections,
+            response_class=self.response_class,
+            response_model_exclude_unset=True,
+            response_model_exclude_none=True,
+            methods=["GET"],
+            endpoint=create_async_endpoint(
+                self.client.get_collection_search, self.collection_search_get_request_model
+            ),
+        )
+
+        self.router.add_api_route(
+            name="Collection Search",
+            path="/collection-search",
+            response_model=Collections,
+            response_class=self.response_class,
+            response_model_exclude_unset=True,
+            response_model_exclude_none=True,
+            methods=["POST"],
+            endpoint=create_async_endpoint(
+                self.client.post_collection_search, self.collection_search_post_request_model
+            ),
+        )
+
+        app.include_router(self.router, tags=["Collection Search Extension"])

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/collectionSearch/request.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/collectionSearch/request.py
@@ -1,0 +1,28 @@
+"""Collection Search extension request models."""
+
+from enum import Enum
+from typing import Any, Dict, Optional, List
+
+import attr
+from pydantic import BaseModel, Field
+from stac_pydantic.shared import BBox
+
+from stac_fastapi.types.search import APIRequest, Limit, str2bbox
+
+from stac_fastapi.types.rfc3339 import DateTimeType, str_to_interval
+
+@attr.s
+class CollectionSearchExtensionGetRequest(APIRequest):
+    """Collection Search extension GET request model."""
+
+    bbox: Optional[BBox] = attr.ib(default=None, converter=str2bbox)
+    datetime: Optional[DateTimeType] = attr.ib(default=None, converter=str_to_interval)
+    limit: Optional[int] = attr.ib(default=10)
+
+
+class CollectionSearchExtensionPostRequest(BaseModel):
+    """Collection Search extension POST request model."""
+
+    bbox: Optional[BBox]
+    datetime: Optional[DateTimeType]
+    limit: Optional[Limit] = Field(default=10)

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -17,7 +17,7 @@ from stac_fastapi.types.conformance import BASE_CONFORMANCE_CLASSES
 from stac_fastapi.types.extension import ApiExtension
 from stac_fastapi.types.requests import get_base_url
 from stac_fastapi.types.rfc3339 import DateTimeType
-from stac_fastapi.types.search import BaseSearchPostRequest
+from stac_fastapi.types.search import BaseSearchPostRequest, BaseCollectionSearchPostRequest
 from stac_fastapi.types.stac import Conformance
 
 NumType = Union[float, int]
@@ -801,3 +801,78 @@ class BaseFiltersClient(abc.ABC):
             "description": "Queryable names for the example STAC API Item Search filter.",
             "properties": {},
         }
+    
+@attr.s
+class AsyncCollectionSearchClient(abc.ABC):
+    """Defines a pattern for implementing the STAC Collection Search extension."""
+
+    @abc.abstractmethod
+    async def post_collection_search(
+        self, search_request: BaseCollectionSearchPostRequest, **kwargs
+    ) -> stac_types.ItemCollection:
+        """Cross catalog search (POST) of collections.
+
+        Called with `POST /collection-search`.
+
+        Args:
+            search_request: search request parameters.
+
+        Returns:
+            A tuple of (collections, next pagination token if any).
+        """
+        ...
+
+    @abc.abstractmethod
+    async def get_collection_search(
+        self,
+        bbox: Optional[BBox] = None,
+        datetime: Optional[DateTimeType] = None,
+        limit: Optional[int] = 10,
+        **kwargs,
+    ) -> stac_types.Collections:
+        """Cross catalog search (GET) of collections.
+
+        Called with `GET /collection-search`.
+
+        Returns:
+            A tuple of (collections, next pagination token if any).
+        """
+        ...
+
+
+@attr.s
+class CollectionSearchClient(abc.ABC):
+    """Defines a pattern for implementing the STAC Collection Search extension."""
+
+    @abc.abstractmethod
+    def post_collection_search(
+        self, search_request: BaseCollectionSearchPostRequest, **kwargs
+    ) -> stac_types.Collections:
+        """Cross catalog search (POST) of collections.
+
+        Called with `POST /collection-search`.
+
+        Args:
+            search_request: search request parameters.
+
+        Returns:
+            A tuple of (collections, next pagination token if any).
+        """
+        ...
+
+    @abc.abstractmethod
+    def get_collection_search(
+        self,
+        bbox: Optional[BBox] = None,
+        datetime: Optional[DateTimeType] = None,
+        limit: Optional[int] = 10,
+        **kwargs,
+    ) -> stac_types.Collections:
+        """Cross catalog search (GET) of collections.
+
+        Called with `GET /collection-search`.
+
+        Returns:
+            A tuple of (collections, next pagination token if any).
+        """
+        ...


### PR DESCRIPTION
Added collection search extension as defined [here](https://github.com/stac-api-extensions/collection-search) to allow searching of collections by bbox and datetime. To test this extension the pull request making changes to the stac-fastapi-elasticsearch-opensearch repository also needs to be merged.