### PR TITLE
Bugfix/json response type error collection search

### DIFF
--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/collectionSearch/collectionSearch.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/collectionSearch/collectionSearch.py
@@ -82,7 +82,7 @@ class CollectionSearchExtension(ApiExtension):
         self.router.add_api_route(
             name="Collection Search",
             path="/collection-search",
-            response_model=Collections,
+            response_model=None,
             response_class=self.response_class,
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
@@ -95,7 +95,7 @@ class CollectionSearchExtension(ApiExtension):
         self.router.add_api_route(
             name="Collection Search",
             path="/collection-search",
-            response_model=Collections,
+            response_model=None,
             response_class=self.response_class,
             response_model_exclude_unset=True,
             response_model_exclude_none=True,

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/collectionSearch/collectionSearch.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/collectionSearch/collectionSearch.py
@@ -5,7 +5,7 @@ from typing import List, Type, Union
 
 import attr
 from fastapi import APIRouter, FastAPI
-from starlette.responses import Response
+from starlette.responses import JSONResponse, Response
 from stac_pydantic.api.collections import Collections
 
 from stac_fastapi.api.models import JSONSchemaResponse
@@ -67,8 +67,7 @@ class CollectionSearchExtension(ApiExtension):
         ]
     )
     router: APIRouter = attr.ib(factory=APIRouter)
-    response_class: Type[Response] = attr.ib(default=JSONSchemaResponse)
-    
+    response_class: Type[Response] = attr.ib(default=JSONResponse)    
 
     def register(self, app: FastAPI) -> None:
         """Register the extension with a FastAPI application.

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/collectionSearch/collectionSearch.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/collectionSearch/collectionSearch.py
@@ -82,7 +82,7 @@ class CollectionSearchExtension(ApiExtension):
         self.router.add_api_route(
             name="Collection Search",
             path="/collection-search",
-            response_model=None,
+            response_model=Collections,
             response_class=self.response_class,
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
@@ -95,7 +95,7 @@ class CollectionSearchExtension(ApiExtension):
         self.router.add_api_route(
             name="Collection Search",
             path="/collection-search",
-            response_model=None,
+            response_model=Collections,
             response_class=self.response_class,
             response_model_exclude_unset=True,
             response_model_exclude_none=True,


### PR DESCRIPTION
- Updated collection search response class to match other `get_collections` function
- Corrected issue where JSON response raised a Validation Error where the input document contained `null` values.