### PR TITLE
Feature/eodhp 280 nested catalog support in stac api

### DIFF
--- a/stac_fastapi/api/stac_fastapi/api/models.py
+++ b/stac_fastapi/api/stac_fastapi/api/models.py
@@ -134,7 +134,7 @@ def create_mixed_request_model(
     # Create new class containing all search query extensions along with catalog_id path attribute
     @attr.s
     class CatalogSearchPostRequestNew(APIRequest):
-        catalog_id: str = attr.ib(default=Path(..., description="Catalog ID"))
+        catalog_path: str = attr.ib(default=Path(..., description="Catalog Path"))
         search_request: temp_model = attr.ib(default=None)
 
     # If full is True, return the new class with all search query extensions and catalog_id path attribute
@@ -235,7 +235,11 @@ def create_post_collections_request_model(
 class CatalogUri(APIRequest):
     """Delete catalog."""
 
-    catalog_id: str = attr.ib(default=Path(..., description="Catalog ID"))
+    catalog_path: str = attr.ib(
+        default=Path(
+            ..., description="Path to selected Catalog", example="cat1/cat2/cat3"
+        )
+    )
 
 
 @attr.s  # type:ignore

--- a/stac_fastapi/api/tests/benchmarks.py
+++ b/stac_fastapi/api/tests/benchmarks.py
@@ -61,13 +61,13 @@ items = [
 
 class CoreClient(BaseCoreClient):
     def post_global_search(
-        self, catalog_id: str, search_request: BaseSearchPostRequest, **kwargs
+        self, catalog_path: str, search_request: BaseSearchPostRequest, **kwargs
     ) -> stac_types.ItemCollection:
         raise NotImplementedError
 
     def get_global_search(
         self,
-        catalogs: Optional[List[str]] = None,
+        catalog_paths: Optional[List[str]] = None,
         collections: Optional[List[str]] = None,
         ids: Optional[List[str]] = None,
         bbox: Optional[List[NumType]] = None,
@@ -79,13 +79,13 @@ class CoreClient(BaseCoreClient):
         raise NotImplementedError
 
     def post_search(
-        self, catalog_id: str, search_request: BaseCatalogSearchPostRequest, **kwargs
+        self, catalog_path: str, search_request: BaseCatalogSearchPostRequest, **kwargs
     ) -> stac_types.ItemCollection:
         raise NotImplementedError
 
     def get_search(
         self,
-        catalogs: Optional[List[str]] = None,
+        catalog_paths: Optional[List[str]] = None,
         collections: Optional[List[str]] = None,
         ids: Optional[List[str]] = None,
         bbox: Optional[List[NumType]] = None,
@@ -97,7 +97,7 @@ class CoreClient(BaseCoreClient):
         raise NotImplementedError
 
     def get_item(
-        self, item_id: str, collection_id: str, catalog_id: str, **kwargs
+        self, item_id: str, collection_id: str, catalog_path: str, **kwargs
     ) -> stac_types.Item:
         raise NotImplementedError
 
@@ -111,7 +111,9 @@ class CoreClient(BaseCoreClient):
             ],
         )
 
-    def all_catalogs(self, **kwargs) -> stac_types.Catalogs:
+    def all_catalogs(
+        self, catalog_path: Optional[str] = None, **kwargs
+    ) -> stac_types.Catalogs:
         return stac_types.Catalogs(
             catalogs=catalogs,
             links=[
@@ -121,15 +123,27 @@ class CoreClient(BaseCoreClient):
             ],
         )
 
+    # def all_nested_catalogs(self, **kwargs) -> stac_types.Catalogs:
+    #     return stac_types.Catalogs(
+    #         catalogs=catalogs,
+    #         links=[
+    #             {"href": "test", "rel": "root"},
+    #             {"href": "test", "rel": "self"},
+    #             {"href": "test", "rel": "parent"},
+    #         ],
+    #     )
+
     def get_collection(
-        self, catalog_id: str, collection_id: str, **kwargs
+        self, catalog_path: str, collection_id: str, **kwargs
     ) -> stac_types.Collection:
         return collections[0]
 
-    def get_catalog_collection(self, catalog_id: str, **kwargs) -> stac_types.Catalogs:
+    def get_catalog_collection(
+        self, catalog_path: str, **kwargs
+    ) -> stac_types.Catalogs:
         return collections[0]
 
-    def get_catalog(self, catalog_id: str, **kwargs) -> stac_types.Catalog:
+    def get_catalog(self, catalog_path: str, **kwargs) -> stac_types.Catalog:
         return catalogs[0]
 
     def item_collection(

--- a/stac_fastapi/api/tests/benchmarks.py
+++ b/stac_fastapi/api/tests/benchmarks.py
@@ -123,16 +123,6 @@ class CoreClient(BaseCoreClient):
             ],
         )
 
-    # def all_nested_catalogs(self, **kwargs) -> stac_types.Catalogs:
-    #     return stac_types.Catalogs(
-    #         catalogs=catalogs,
-    #         links=[
-    #             {"href": "test", "rel": "root"},
-    #             {"href": "test", "rel": "self"},
-    #             {"href": "test", "rel": "parent"},
-    #         ],
-    #     )
-
     def get_collection(
         self, catalog_path: str, collection_id: str, **kwargs
     ) -> stac_types.Collection:

--- a/stac_fastapi/extensions/stac_fastapi/extensions/third_party/bulk_transactions.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/third_party/bulk_transactions.py
@@ -47,7 +47,7 @@ class BaseBulkTransactionsClient(abc.ABC):
     @abc.abstractmethod
     def bulk_item_insert(
         self,
-        catalog_id: str,
+        catalog_path: str,
         items: Items,
         chunk_size: Optional[int] = None,
         **kwargs,
@@ -71,7 +71,7 @@ class AsyncBaseBulkTransactionsClient(abc.ABC):
     @abc.abstractmethod
     async def bulk_item_insert(
         self,
-        catalog_id: str,
+        catalog_path: str,
         items: Items,
         **kwargs,
     ) -> str:
@@ -132,7 +132,7 @@ class BulkTransactionExtension(ApiExtension):
         router = APIRouter(prefix=app.state.router_prefix)
         router.add_api_route(
             name="Bulk Create Item",
-            path="/collections/{collection_id}/bulk_items",
+            path="/catalogs/{catalog_path:path}/collections/{collection_id}/bulk_items",
             response_model=str,
             response_model_exclude_unset=True,
             response_model_exclude_none=True,

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -608,7 +608,6 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
         """
         ...
 
-
     @abc.abstractmethod
     def get_collection(
         self, catalog_path: str, collection_id: str, **kwargs
@@ -917,7 +916,6 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
             A list of catalogs.
         """
         ...
-s
 
     @abc.abstractmethod
     async def get_collection(

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -608,16 +608,6 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
         """
         ...
 
-    # @abc.abstractmethod
-    # def all_nested_catalogs(self, **kwargs) -> stac_types.Catalogs:
-    #     """Get all available catalogs.
-
-    #     Called with `GET /catalogs`.
-
-    #     Returns:
-    #         A list of catalogs.
-    #     """
-    #     ...
 
     @abc.abstractmethod
     def get_collection(
@@ -927,17 +917,7 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
             A list of catalogs.
         """
         ...
-
-    # @abc.abstractmethod
-    # async def all_nested_catalogs(self, **kwargs) -> stac_types.Catalogs:
-    #     """Get all available catalogs.
-
-    #     Called with `GET {catalog_path}/catalogs`.
-
-    #     Returns:
-    #         A list of catalogs.
-    #     """
-    #     ...
+s
 
     @abc.abstractmethod
     async def get_collection(

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -58,7 +58,7 @@ class BaseTransactionsClient(abc.ABC):
     @abc.abstractmethod
     def update_item(
         self,
-        catalog_id: str,
+        catalog_path: str,
         collection_id: str,
         item_id: str,
         item: stac_types.Item,
@@ -82,7 +82,7 @@ class BaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     def delete_item(
-        self, item_id: str, collection_id: str, catalog_id: str, **kwargs
+        self, item_id: str, collection_id: str, catalog_path: str, **kwargs
     ) -> Optional[Union[stac_types.Item, Response]]:
         """Delete an item from a collection.
 
@@ -99,7 +99,7 @@ class BaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     def create_collection(
-        self, catalog_id: str, collection: stac_types.Collection, **kwargs
+        self, catalog_path: str, collection: stac_types.Collection, **kwargs
     ) -> Optional[Union[stac_types.Collection, Response]]:
         """Create a new collection.
 
@@ -115,11 +115,27 @@ class BaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     def create_catalog(
-        self, catalog: stac_types.Catalog, **kwargs
+        self, catalog: stac_types.Catalog, catalog_path: Optional[str], **kwargs
     ) -> Optional[Union[stac_types.Catalog, Response]]:
         """Create a new catalog.
 
         Called with `POST /catalogs`.
+
+        Args:
+            catalog: the catalog
+
+        Returns:
+            The catalog that was created.
+        """
+        ...
+
+    @abc.abstractmethod
+    def create_super_catalog(
+        self, catalog: stac_types.Catalog, **kwargs
+    ) -> Optional[Union[stac_types.Catalog, Response]]:
+        """Create a new catalog.
+
+        Called with `POST /`.
 
         Args:
             catalog: the catalog
@@ -151,7 +167,7 @@ class BaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     def delete_collection(
-        self, catalog_id: str, collection_id: str, **kwargs
+        self, catalog_path: str, collection_id: str, **kwargs
     ) -> Optional[Union[stac_types.Collection, Response]]:
         """Delete a collection.
 
@@ -193,7 +209,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
     @abc.abstractmethod
     async def update_item(
         self,
-        catalog_id: str,
+        catalog_path: str,
         collection_id: str,
         item_id: str,
         item: stac_types.Item,
@@ -216,7 +232,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     async def delete_item(
-        self, item_id: str, collection_id: str, catalog_id: str, **kwargs
+        self, item_id: str, collection_id: str, catalog_path: str, **kwargs
     ) -> Optional[Union[stac_types.Item, Response]]:
         """Delete an item from a collection.
 
@@ -250,7 +266,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
     @abc.abstractmethod
     async def update_collection(
         self,
-        catalog_id: str,
+        catalog_path: str,
         collection_id: str,
         collection: stac_types.Collection,
         **kwargs,
@@ -273,7 +289,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     async def delete_collection(
-        self, catalog_id: str, collection_id: str, **kwargs
+        self, catalog_path: str, collection_id: str, **kwargs
     ) -> Optional[Union[stac_types.Collection, Response]]:
         """Delete a collection.
 
@@ -488,7 +504,7 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
     @abc.abstractmethod
     def get_global_search(
         self,
-        catalogs: Optional[List[str]] = None,
+        catalog_paths: Optional[List[str]] = None,
         collections: Optional[List[str]] = None,
         ids: Optional[List[str]] = None,
         bbox: Optional[BBox] = None,
@@ -512,7 +528,7 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
 
     @abc.abstractmethod
     def post_search(
-        self, catalog_id: str, search_request: BaseCatalogSearchPostRequest, **kwargs
+        self, catalog_path: str, search_request: BaseCatalogSearchPostRequest, **kwargs
     ) -> stac_types.ItemCollection:
         """Single catalog item search (POST).
 
@@ -529,7 +545,7 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
     @abc.abstractmethod
     def get_search(
         self,
-        catalog_id: str,
+        catalog_path: str,
         collections: Optional[List[str]] = None,
         ids: Optional[List[str]] = None,
         bbox: Optional[BBox] = None,
@@ -553,7 +569,7 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
 
     @abc.abstractmethod
     def get_item(
-        self, item_id: str, collection_id: str, catalog_id: str, **kwargs
+        self, item_id: str, collection_id: str, catalog_path: str, **kwargs
     ) -> stac_types.Item:
         """Get item by id.
 
@@ -580,7 +596,9 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
         ...
 
     @abc.abstractmethod
-    def all_catalogs(self, **kwargs) -> stac_types.Catalogs:
+    def all_catalogs(
+        self, catalog_path: Optional[str] = None, **kwargs
+    ) -> stac_types.Catalogs:
         """Get all available catalogs.
 
         Called with `GET /catalogs`.
@@ -590,9 +608,20 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
         """
         ...
 
+    # @abc.abstractmethod
+    # def all_nested_catalogs(self, **kwargs) -> stac_types.Catalogs:
+    #     """Get all available catalogs.
+
+    #     Called with `GET /catalogs`.
+
+    #     Returns:
+    #         A list of catalogs.
+    #     """
+    #     ...
+
     @abc.abstractmethod
     def get_collection(
-        self, catalog_id: str, collection_id: str, **kwargs
+        self, catalog_path: str, collection_id: str, **kwargs
     ) -> stac_types.Collection:
         """Get collection by id.
 
@@ -607,7 +636,7 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
         ...
 
     @abc.abstractmethod
-    def get_catalog(self, catalog_id: str, **kwargs) -> stac_types.Catalog:
+    def get_catalog(self, catalog_path: str, **kwargs) -> stac_types.Catalog:
         """Get catalog by id.
 
         Called with `GET /catalogs/{catalog_id}`.
@@ -622,7 +651,7 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
 
     @abc.abstractmethod
     def get_catalog_collections(
-        self, catalog_id: str, **kwargs
+        self, catalog_path: str, **kwargs
     ) -> stac_types.Collections:
         """Get collections by catalog id.
 
@@ -795,7 +824,7 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
     @abc.abstractmethod
     async def get_global_search(
         self,
-        catalogs: Optional[List[str]] = None,
+        catalog_paths: Optional[List[str]] = None,
         collections: Optional[List[str]] = None,
         ids: Optional[List[str]] = None,
         bbox: Optional[BBox] = None,
@@ -820,7 +849,7 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
     @abc.abstractmethod
     async def get_search(
         self,
-        catalog_id: str,
+        catalog_path: str,
         collections: Optional[List[str]] = None,
         ids: Optional[List[str]] = None,
         bbox: Optional[BBox] = None,
@@ -844,7 +873,7 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
 
     @abc.abstractmethod
     async def post_search(
-        self, catalog_id: str, search_request: BaseCatalogSearchPostRequest, **kwargs
+        self, catalog_path: str, search_request: BaseCatalogSearchPostRequest, **kwargs
     ) -> stac_types.ItemCollection:
         """Single catalog item search (POST).
 
@@ -860,7 +889,7 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
 
     @abc.abstractmethod
     async def get_item(
-        self, item_id: str, collection_id: str, catalog_id: str, **kwargs
+        self, item_id: str, collection_id: str, catalog_path: str, **kwargs
     ) -> stac_types.Item:
         """Get item by id.
 
@@ -887,7 +916,9 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def all_catalogs(self, **kwargs) -> stac_types.Catalogs:
+    async def all_catalogs(
+        self, catalog_path: Optional[str] = None, **kwargs
+    ) -> stac_types.Catalogs:
         """Get all available catalogs.
 
         Called with `GET /catalogs`.
@@ -896,6 +927,17 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
             A list of catalogs.
         """
         ...
+
+    # @abc.abstractmethod
+    # async def all_nested_catalogs(self, **kwargs) -> stac_types.Catalogs:
+    #     """Get all available catalogs.
+
+    #     Called with `GET {catalog_path}/catalogs`.
+
+    #     Returns:
+    #         A list of catalogs.
+    #     """
+    #     ...
 
     @abc.abstractmethod
     async def get_collection(
@@ -914,7 +956,7 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def get_catalog(self, catalog_id: str, **kwargs) -> stac_types.Catalog:
+    async def get_catalog(self, catalog_path: str, **kwargs) -> stac_types.Catalog:
         """Get catalog by id.
 
         Called with `GET /catalogs/{catalog_id}`.

--- a/stac_fastapi/types/stac_fastapi/types/links.py
+++ b/stac_fastapi/types/stac_fastapi/types/links.py
@@ -43,7 +43,7 @@ def resolve_links(links: list, base_url: str) -> List[Dict]:
 class BaseLinks:
     """Create inferred links common to collections and items."""
 
-    catalog_id: str = attr.ib()
+    catalog_path: str = attr.ib()  # a string of catalogs separated by "/"
     collection_id: str = attr.ib()
     base_url: str = attr.ib()
 
@@ -52,7 +52,7 @@ class BaseLinks:
         return dict(
             rel=Relations.root,
             type=MimeTypes.json,
-            href=urljoin(self.base_url, f"catalogs/{self.catalog_id}"),
+            href=urljoin(self.base_url, f"catalogs/{self.catalog_path}"),
         )
 
 
@@ -67,7 +67,7 @@ class CollectionLinks(BaseLinks):
             type=MimeTypes.json,
             href=urljoin(
                 self.base_url,
-                f"catalogs/{self.catalog_id}/collections/{self.collection_id}",
+                f"catalogs/{self.catalog_path}/collections/{self.collection_id}",
             ),
         )
 
@@ -76,7 +76,7 @@ class CollectionLinks(BaseLinks):
         return dict(
             rel=Relations.parent,
             type=MimeTypes.json,
-            href=urljoin(self.base_url, f"catalogs/{self.catalog_id}"),
+            href=urljoin(self.base_url, f"catalogs/{self.catalog_path}"),
         )
 
     def items(self) -> Dict[str, Any]:
@@ -86,7 +86,7 @@ class CollectionLinks(BaseLinks):
             type=MimeTypes.geojson,
             href=urljoin(
                 self.base_url,
-                f"catalogs/{self.catalog_id}/collections/{self.collection_id}/items",
+                f"catalogs/{self.catalog_path}/collections/{self.collection_id}/items",
             ),
         )
 
@@ -106,7 +106,7 @@ class BaseCatalogLinks:
     """Create inferred links common to catalogs."""
 
     base_url: str = attr.ib()
-    catalog_id: str = attr.ib()
+    catalog_path: str = attr.ib()
 
     def root(self) -> Dict[str, Any]:
         """Return the catalog root."""
@@ -122,12 +122,18 @@ class CatalogLinks(BaseCatalogLinks):
         return dict(
             rel=Relations.self,
             type=MimeTypes.json,
-            href=urljoin(self.base_url, f"catalogs/{self.catalog_id}"),
+            href=urljoin(self.base_url, f"catalogs/{self.catalog_path}"),
         )
 
     def parent(self) -> Dict[str, Any]:
         """Create the `parent` link."""
-        return dict(rel=Relations.parent, type=MimeTypes.json, href=self.base_url)
+        catalog_path_list = self.catalog_path.split("/")
+        if len(catalog_path_list) == 1:
+            temp_catalog_path = ""
+        else:
+            temp_catalog_path = "/".join(catalog_path_list[:-1])
+        href = urljoin(self.base_url, f"/catalogs/{temp_catalog_path}")
+        return dict(rel=Relations.parent, type=MimeTypes.json, href=href)
 
     def create_links(self) -> List[Dict[str, Any]]:
         """Return all inferred links."""
@@ -149,7 +155,7 @@ class ItemLinks(BaseLinks):
             type=MimeTypes.geojson,
             href=urljoin(
                 self.base_url,
-                f"catalogs/{self.catalog_id}/collections/{self.collection_id}/items/{self.item_id}",
+                f"catalogs/{self.catalog_path}/collections/{self.collection_id}/items/{self.item_id}",
             ),
         )
 
@@ -160,7 +166,7 @@ class ItemLinks(BaseLinks):
             type=MimeTypes.json,
             href=urljoin(
                 self.base_url,
-                f"catalogs/{self.catalog_id}/collections/{self.collection_id}",
+                f"catalogs/{self.catalog_path}/collections/{self.collection_id}",
             ),
         )
 
@@ -171,7 +177,7 @@ class ItemLinks(BaseLinks):
             type=MimeTypes.json,
             href=urljoin(
                 self.base_url,
-                f"catalogs/{self.catalog_id}/collections/{self.collection_id}",
+                f"catalogs/{self.catalog_path}/collections/{self.collection_id}",
             ),
         )
 

--- a/stac_fastapi/types/stac_fastapi/types/search.py
+++ b/stac_fastapi/types/stac_fastapi/types/search.py
@@ -107,7 +107,7 @@ class APIRequest(abc.ABC):
 class BaseSearchGetRequest(APIRequest):
     """Base arguments for GET Request."""
 
-    catalogs: Optional[str] = attr.ib(default=None, converter=str2list)
+    catalog_paths: Optional[str] = attr.ib(default=None, converter=str2list)
     collections: Optional[str] = attr.ib(default=None, converter=str2list)
     ids: Optional[str] = attr.ib(default=None, converter=str2list)
     bbox: Optional[BBox] = attr.ib(default=None, converter=str2bbox)
@@ -120,7 +120,7 @@ class BaseSearchGetRequest(APIRequest):
 class BaseCatalogSearchGetRequest(APIRequest):
     """Base arguments for GET Request for searching items in a specific catalog."""
 
-    catalog_id: str = attr.ib(default=Path(..., description="Catalog ID"))
+    catalog_path: str = attr.ib(default=Path(..., description="Catalog Path"))
     collections: Optional[str] = attr.ib(default=None, converter=str2list)
     ids: Optional[str] = attr.ib(default=None, converter=str2list)
     bbox: Optional[BBox] = attr.ib(default=None, converter=str2bbox)
@@ -140,7 +140,7 @@ class BaseSearchPostRequest(Search):
     https://github.com/stac-utils/stac-pydantic/pull/100
     """
 
-    catalogs: Optional[List[str]]
+    catalog_paths: Optional[List[str]]
     collections: Optional[List[str]]
     ids: Optional[List[str]]
     bbox: Optional[BBox]
@@ -342,7 +342,7 @@ class BaseCatalogSearchPostRequest(Search):
 class CatalogSearchPostRequest(APIRequest):
     """Search model for searching items in a specific catalog."""
 
-    catalog_id: str = attr.ib(default=Path(..., description="Catalog ID"))
+    catalog_path: str = attr.ib(default=Path(..., description="Catalog Path"))
     search_request: BaseCatalogSearchPostRequest = attr.ib(default=None)
 
 


### PR DESCRIPTION
## Nested Catalog Support
Updated endpoints and types to allow catalogs to be nested within other catalogs. This includes adding a new `catalog_path` variable to most endpoints to allow more specific identification of catalogs for nesting functionality.
Also updating link functionality to ensure all nested items can be retrieved as expected via the correct URL.