### PR TITLE
Remove duplicate registration function

### DIFF
--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -489,7 +489,6 @@ class StacApi:
         self.register_get_all_catalogs()
         self.register_get_collection()
         self.register_get_catalog()
-        self.register_get_item_collection()
         self.register_get_collections()
 
     def customize_openapi(self) -> Optional[Dict[str, Any]]:


### PR DESCRIPTION
Bugfix to remove duplicate register function call, causing warning in deployment