### PR TITLE
Bugfix/introduce pydantic validator for collection search

### DIFF
--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -137,14 +137,6 @@ class StacApi:
         )
     )
     route_dependencies: List[Tuple[List[Scope], List[Depends]]] = attr.ib(default=[])
-    # Used to enable the /collections search extension (GET)
-    collections_get_request_model: Type[BaseCollectionSearchGetRequest] = attr.ib(
-        default=EmptyRequest
-    )
-    # Used to enable the /collections search extension (POST)
-    collections_post_request_model: Type[BaseCollectionSearchPostRequest] = attr.ib(
-        default=BaseModel
-    )
 
     def get_extension(self, extension: Type[ApiExtension]) -> Optional[ApiExtension]:
         """Get an extension.
@@ -322,22 +314,23 @@ class StacApi:
             None
         """
         collection_search_ext = self.get_extension(CollectionSearchExtension)
-        self.router.add_api_route(
-            name="Get Collections",
-            path="/collections",
-            response_model=(
-                (Collections if not collection_search_ext else None)
-                if self.settings.enable_response_models
-                else None
-            ),
-            response_class=self.response_class,
-            response_model_exclude_unset=True,
-            response_model_exclude_none=True,
-            methods=["GET"],
-            endpoint=create_async_endpoint(
-                self.client.all_collections, self.collections_get_request_model
-            ),
-        )
+        if not collection_search_ext:
+            self.router.add_api_route(
+                name="Get Collections",
+                path="/collections",
+                response_model=(
+                    (Collections if not collection_search_ext else None)
+                    if self.settings.enable_response_models
+                    else None
+                ),
+                response_class=self.response_class,
+                response_model_exclude_unset=True,
+                response_model_exclude_none=True,
+                methods=["GET"],
+                endpoint=create_async_endpoint(
+                    self.client.all_collections, EmptyRequest
+                ),
+            )
 
     def register_get_catalogs(self):
         """Register get catalogs endpoint (GET /catalogs).

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/collection_search.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/collection_search.py
@@ -15,7 +15,10 @@ from stac_fastapi.types.core import (
     BaseCollectionSearchClient,
 )
 from stac_fastapi.types.extension import ApiExtension
-from stac_fastapi.types.search import BaseCollectionSearchPostRequest
+from stac_fastapi.types.search import (
+    BaseCollectionSearchGetRequest,
+    BaseCollectionSearchPostRequest,
+)
 
 from .request import (
     CollectionSearchExtensionGetRequest,
@@ -64,6 +67,9 @@ class CollectionSearchExtension(ApiExtension):
     collections_post_request_model: Type[BaseCollectionSearchPostRequest] = attr.ib(
         default=BaseCollectionSearchPostRequest
     )
+    collections_get_request_model: Type[BaseCollectionSearchGetRequest] = attr.ib(
+        default=BaseCollectionSearchGetRequest
+    )
 
     client: Union[AsyncBaseCollectionSearchClient, BaseCollectionSearchClient] = (
         attr.ib(factory=BaseCollectionSearchClient)
@@ -104,4 +110,20 @@ class CollectionSearchExtension(ApiExtension):
                 self.client.post_all_collections, self.collections_post_request_model
             ),
         )
+
+        self.router.add_api_route(
+            name="Get Collections",
+            path="/collections",
+            response_model=(
+                Collections if self.settings.enable_response_models else None
+            ),
+            response_class=self.response_class,
+            response_model_exclude_unset=True,
+            response_model_exclude_none=True,
+            methods=["GET"],
+            endpoint=create_async_endpoint(
+                self.client.get_all_collections, self.collections_get_request_model
+            ),
+        )
+
         app.include_router(self.router)

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/request.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/request.py
@@ -1,13 +1,13 @@
 """Collection Search extension request models."""
 
-from typing import Optional
+from typing import List, Optional
 
 import attr
 from pydantic import BaseModel, Field
 from stac_pydantic.shared import BBox
 
 from stac_fastapi.types.rfc3339 import DateTimeType, str_to_interval
-from stac_fastapi.types.search import APIRequest, Limit, str2bbox
+from stac_fastapi.types.search import APIRequest, Limit, str2bbox, str2list
 
 
 @attr.s
@@ -17,7 +17,7 @@ class CollectionSearchExtensionGetRequest(APIRequest):
     bbox: Optional[BBox] = attr.ib(default=None, converter=str2bbox)
     datetime: Optional[DateTimeType] = attr.ib(default=None, converter=str_to_interval)
     limit: Optional[int] = attr.ib(default=10)
-    q: Optional[str] = attr.ib(default=None)
+    q: Optional[List[str]] = attr.ib(default=None, converter=str2list)
 
 
 class CollectionSearchExtensionPostRequest(BaseModel):
@@ -26,4 +26,4 @@ class CollectionSearchExtensionPostRequest(BaseModel):
     bbox: Optional[BBox]
     datetime: Optional[DateTimeType]
     limit: Optional[Limit] = Field(default=10)
-    q: Optional[str]
+    q: Optional[List[str]]

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/discoverySearch/request.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/discoverySearch/request.py
@@ -1,23 +1,23 @@
 """Discovery Search extension request models."""
 
-from typing import Optional
+from typing import List, Optional
 
 import attr
 from pydantic import BaseModel, Field
 
-from stac_fastapi.types.search import APIRequest, Limit
+from stac_fastapi.types.search import APIRequest, Limit, str2list
 
 
 @attr.s
 class DiscoverySearchExtensionGetRequest(APIRequest):
     """Discovery Search extension GET request model."""
 
-    q: Optional[str] = attr.ib(default=None)
+    q: Optional[List[str]] = attr.ib(default=None, converter=str2list)
     limit: Optional[int] = attr.ib(default=10)
 
 
 class DiscoverySearchExtensionPostRequest(BaseModel):
     """Discovery Search extension POST request model."""
 
-    q: Optional[str]
+    q: Optional[List[str]]
     limit: Optional[Limit] = Field(default=10)

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -1032,6 +1032,22 @@ class AsyncBaseCollectionSearchClient(abc.ABC):
         self, search_request: BaseCollectionSearchPostRequest, **kwargs
     ) -> stac_types.Collections:
         """Get all available collections.
+        Called with `POST /collections`.
+        Returns:
+            A list of collections.
+        """
+        return stac_types.Collections(collections=[])
+
+    async def get_all_collections(
+        self,
+        request: Request,
+        bbox: Optional[List[NumType]] = None,
+        datetime: Optional[Union[str, DateTimeType]] = None,
+        limit: Optional[int] = 10,
+        q: Optional[List[str]] = None,
+        **kwargs,
+    ) -> stac_types.Collections:
+        """Get all available collections.
         Called with `GET /collections`.
         Returns:
             A list of collections.
@@ -1043,8 +1059,24 @@ class AsyncBaseCollectionSearchClient(abc.ABC):
 class BaseCollectionSearchClient(abc.ABC):
     """Defines a pattern for implementing the STAC Collection Search extension."""
 
-    async def post_all_collections(
+    def post_all_collections(
         self, search_request: BaseCollectionSearchPostRequest, **kwargs
+    ) -> stac_types.Collections:
+        """Get all available collections.
+        Called with `GET /collections`.
+        Returns:
+            A list of collections.
+        """
+        return stac_types.Collections(collections=[])
+
+    def get_all_collections(
+        self,
+        request: Request,
+        bbox: Optional[List[NumType]] = None,
+        datetime: Optional[Union[str, DateTimeType]] = None,
+        limit: Optional[int] = 10,
+        q: Optional[List[str]] = None,
+        **kwargs,
     ) -> stac_types.Collections:
         """Get all available collections.
         Called with `GET /collections`.
@@ -1077,7 +1109,7 @@ class AsyncDiscoverySearchClient(abc.ABC):
     @abc.abstractmethod
     async def get_discovery_search(
         self,
-        q: Optional[str] = None,
+        q: Optional[List[str]] = None,
         limit: Optional[int] = 10,
         **kwargs,
     ) -> stac_types.Collections:
@@ -1114,7 +1146,7 @@ class DiscoverySearchClient(abc.ABC):
     @abc.abstractmethod
     def get_discovery_search(
         self,
-        q: Optional[str] = None,
+        q: Optional[List[str]] = None,
         limit: Optional[int] = 10,
         **kwargs,
     ) -> stac_types.Collections:

--- a/stac_fastapi/types/stac_fastapi/types/search.py
+++ b/stac_fastapi/types/stac_fastapi/types/search.py
@@ -353,7 +353,7 @@ class BaseCollectionSearchGetRequest(APIRequest):
     bbox: Optional[BBox] = attr.ib(default=None, converter=str2bbox)
     datetime: Optional[DateTimeType] = attr.ib(default=None, converter=str_to_interval)
     limit: Optional[int] = attr.ib(default=10)
-    q: Optional[str] = attr.ib(default=None)
+    q: Optional[List[str]] = attr.ib(default=None, converter=str2list)
 
 
 class BaseCollectionSearchPostRequest(BaseModel):
@@ -365,7 +365,7 @@ class BaseCollectionSearchPostRequest(BaseModel):
     bbox: Optional[BBox]
     datetime: Optional[DateTimeType]
     limit: Optional[Limit] = 10
-    q: Optional[str]
+    q: Optional[List[str]]
 
     @validator("bbox", pre=True)
     def validate_bbox(cls, v: Union[str, BBox]) -> BBox:
@@ -397,8 +397,6 @@ class BaseCollectionSearchPostRequest(BaseModel):
             if xmin < -180 or ymin < -90 or xmax > 180 or ymax > 90:
                 raise ValueError("Bounding box must be within (-180, -90, 180, 90)")
         return v
-    
-    
 
     @validator("datetime", pre=True)
     def validate_datetime(cls, v: Union[str, DateTimeType]) -> DateTimeType:
@@ -412,7 +410,7 @@ class BaseCollectionSearchPostRequest(BaseModel):
 class BaseDiscoverySearchGetRequest(APIRequest):
     """Base arguments for Collection Search GET Request."""
 
-    q: Optional[str] = attr.ib(default=None)
+    q: Optional[List[str]] = attr.ib(default=None, converter=str2list)
     limit: Optional[int] = attr.ib(default=10)
 
 
@@ -423,5 +421,5 @@ class BaseDiscoverySearchPostRequest(BaseModel):
     model.
     """
 
-    q: Optional[str]
+    q: Optional[List[str]]
     limit: Optional[Limit] = Field(default=10)


### PR DESCRIPTION
Bugfix to introduce pydantic type checking for collection search. 
Also moving collection-search extension code to the collection-search extension module, to better split up the implementation.
Updated keyword search input to be a list, rather than a string, as specified in the extension definition.