### PR TITLE
Feature/eodhp 481 access control for resource catalogue entries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ## EODHP
 The following changes have been made for the EODHP project
+### V0.3.8 - 2024-07-30
+Access-Control Logic in Catalog
+- Adding access control to catalogs and collections added to the catalogue
+- Access limited based on incoming `authorization` header username
+- Workspace parameter used when creating/editing entries to ensure workspace has required access to make the requested changes
+- Access determined by hashing the provided username or workspace name, storing in elasticsearch and filtering results
 ### v0.3.7 - 2024-07-02
 Catalog creation logic improvement
 - Ensure parent catalog exists before creating child

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,72 @@
 # Changelog
 
+## EODHP
+The following changes have been made for the EODHP project
+### v0.3.7 - 2024-07-02
+Catalog creation logic improvement
+- Ensure parent catalog exists before creating child
+- Two new functions implemented (async and sync) for catalog preparation
+
+Code clean up
+  - Comments for nested catalog logic
+  - Correct response code for incorrect query parameters when searching
+  - Split up collection-search extension from core `/collections` implementation
+  - Defining abstract functions for collection and discovery search extensions  
+
+Bugfixes
+  - Remove unnecessary parameter from collection-search call
+  - Improve discovery-search implementation to ensure all nested catalogs and collections are returned in catalog responses
+  - Corrected links in response form `/catalogs` endpoints
+### v0.3.6 - 2024-06-14
+## Support nested catalogs
+- Data within (arbitrarily) nested catalogs can be accessed as before with the provided catalog path parameter, e.g. `/supported-datasets/dataset-1`
+- Requires `catalog_path` parameter to be provided to specify where in the catalog directories the data should be placed/recalled from
+- Update endpoints to support nested catalog definition in URL path
+- Better support for STAC-Browser and pystac python client:
+  - Updating link generator logic
+### v0.3.5 - 2024-05-31
+Support configuration for read-only deployments:
+- Allow transaction extensions (including Bulk Transactions) to be disabled by environment variable (STAC_FASTAPI_ENABLE_TRANSACTIONS) at deployment time
+- STAC-fastapi instances can be defined as either read-only (transaction endpoints disabled) or read-write (with all transactions endpoints enabled)
+
+The following bugs were also addressed:
+- Corrected update catalog functionality to reindex all items sitting within the updated catalog when the catalog id is changed
+- Corrected issue with pagination links being broken and added support for discovery and collections search
+### v0.3.4 - 2024-05-14
+#### Added new endpoint to allow free-text searching of collections and catalogues:
+- New endpoints:
+  - Discovery Search (GET/POST)
+  - This queries title, description and keyword (collections only) fields when available
+#### Added support for catalogues to split up collections and items into catalogues of data
+  - This leads to updates for the following endpoints to filter by catalogues:
+    - Get Collection
+    - Get ItemCollection
+    - Get CatalogCollections
+    - Create Item
+    - Update Item
+    - Delete Item
+    - Create Collection
+    - Update Collection
+    - Delete Collection
+  - New endpoints added for catalogues:
+    - Update Catalog
+    - Create Catalog
+    - Delete Catalog
+    - Get Catalogs
+##### Minor changes
+- Update to the datetime handling for Get ItemCollection to include string converter.
+### v0.3.3 - 2024-05-08
+Including fix to address incorrect links returned from `/search` and `/collection-search` endpoints defining the `self` and `next` item locations.
+### v0.3.2 - 2024-05-01
+Bugfixes:
+- Bugfix for missing collection search links
+- Bugfix to address JSON validation error in search results
+### V0.3.1 - 2024-04-26
+General code clean up to improve initialisation commands
+### V3.0.0 - 2024-04-23
+Added [collection search](https://github.com/stac-api-extensions/collection-search) to STAC Fastapi  allowing spatial and temporal searching of collections by BBOX and datetime.
+
+
 ## [Unreleased]
 
 ## [2.5.2] - 2024-04-19

--- a/stac_fastapi/api/setup.py
+++ b/stac_fastapi/api/setup.py
@@ -11,6 +11,7 @@ install_requires = [
     "stac_pydantic==2.0.*",
     "brotli_asgi",
     "stac-fastapi.types",
+    "pyjwt",
 ]
 
 extra_reqs = {

--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -150,7 +150,6 @@ class StacApi:
             if isinstance(ext, extension):
                 return ext
         return None
-   
 
     def register_landing_page(self):
         """Register landing page (GET /).

--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -7,7 +7,6 @@ from brotli_asgi import BrotliMiddleware
 from fastapi import APIRouter, FastAPI
 from fastapi.openapi.utils import get_openapi
 from fastapi.params import Depends
-from pydantic import BaseModel
 from stac_pydantic import Catalog, Collection, Item, ItemCollection
 from stac_pydantic.api import ConformanceClasses, LandingPage
 from stac_pydantic.api.collections import Collections
@@ -151,6 +150,7 @@ class StacApi:
             if isinstance(ext, extension):
                 return ext
         return None
+   
 
     def register_landing_page(self):
         """Register landing page (GET /).

--- a/stac_fastapi/api/stac_fastapi/api/routes.py
+++ b/stac_fastapi/api/stac_fastapi/api/routes.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Dict, List, Optional, Type, TypedDict, Union
 
 from fastapi import Depends, params
 from fastapi.dependencies.utils import get_parameterless_sub_dependant
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from pydantic import BaseModel
 from starlette.concurrency import run_in_threadpool
 from starlette.requests import Request
@@ -15,6 +16,8 @@ from starlette.routing import BaseRoute, Match
 from starlette.status import HTTP_204_NO_CONTENT
 
 from stac_fastapi.api.models import APIRequest
+
+import jwt
 
 
 def _wrap_response(resp: Any) -> Any:
@@ -32,6 +35,27 @@ def sync_to_async(func):
         return await run_in_threadpool(func, *args, **kwargs)
 
     return run
+
+# Define the OAuth2 scheme for Bearer token
+bearer_scheme = HTTPBearer(auto_error=False)
+
+# TODO: Also extract group information from the headers
+def extract_headers(credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme)) -> Dict[str, str]:
+        """Extract headers from request.
+
+        Args:
+            token: The OAuth2 token extracted from the Authorization header.
+
+        Returns:
+            Dict of headers.
+        """
+        if credentials:
+            decoded_jwt = jwt.decode(credentials.credentials, options={"verify_signature": False}, algorithms=["HS256"])
+            username = decoded_jwt.get("preferred_username")
+        else:
+            username = ""
+
+        return {"X-Username": username} # Allows support for more headers in future, e.g. group information
 
 
 def create_async_endpoint(
@@ -58,27 +82,30 @@ def create_async_endpoint(
         async def _endpoint(
             request: Request,
             request_data: request_model = Depends(),  # type:ignore
+            username_header = Depends(extract_headers),
         ):
             """Endpoint."""
-            return _wrap_response(await func(request=request, **request_data.kwargs()))
+            return _wrap_response(await func(request=request, username_header=username_header, **request_data.kwargs()))
 
     elif issubclass(request_model, BaseModel):
 
         async def _endpoint(
             request: Request,
             request_data: request_model,  # type:ignore
+            username_header = Depends(extract_headers),
         ):
             """Endpoint."""
-            return _wrap_response(await func(request_data, request=request))
+            return _wrap_response(await func(request_data, username_header=username_header, request=request))
 
     else:
 
         async def _endpoint(
             request: Request,
             request_data: Dict[str, Any],  # type:ignore
+            username_header = Depends(extract_headers),
         ):
             """Endpoint."""
-            return _wrap_response(await func(request_data, request=request))
+            return _wrap_response(await func(request_data, username_header=username_header, request=request))
 
     return _endpoint
 

--- a/stac_fastapi/api/stac_fastapi/api/routes.py
+++ b/stac_fastapi/api/stac_fastapi/api/routes.py
@@ -5,9 +5,10 @@ import inspect
 import warnings
 from typing import Any, Callable, Dict, List, Optional, Type, TypedDict, Union
 
+import jwt
 from fastapi import Depends, params
 from fastapi.dependencies.utils import get_parameterless_sub_dependant
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
 from starlette.concurrency import run_in_threadpool
 from starlette.requests import Request
@@ -16,8 +17,6 @@ from starlette.routing import BaseRoute, Match
 from starlette.status import HTTP_204_NO_CONTENT
 
 from stac_fastapi.api.models import APIRequest
-
-import jwt
 
 
 def _wrap_response(resp: Any) -> Any:
@@ -36,26 +35,36 @@ def sync_to_async(func):
 
     return run
 
+
 # Define the OAuth2 scheme for Bearer token
 bearer_scheme = HTTPBearer(auto_error=False)
 
+
 # TODO: Also extract group information from the headers
-def extract_headers(credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme)) -> Dict[str, str]:
-        """Extract headers from request.
+def extract_headers(
+    credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
+) -> Dict[str, str]:
+    """Extract headers from request.
 
-        Args:
-            token: The OAuth2 token extracted from the Authorization header.
+    Args:
+        token: The OAuth2 token extracted from the Authorization header.
 
-        Returns:
-            Dict of headers.
-        """
-        if credentials:
-            decoded_jwt = jwt.decode(credentials.credentials, options={"verify_signature": False}, algorithms=["HS256"])
-            username = decoded_jwt.get("preferred_username")
-        else:
-            username = ""
+    Returns:
+        Dict of headers.
+    """
+    if credentials:
+        decoded_jwt = jwt.decode(
+            credentials.credentials,
+            options={"verify_signature": False},
+            algorithms=["HS256"],
+        )
+        username = decoded_jwt.get("preferred_username")
+    else:
+        username = ""
 
-        return {"X-Username": username} # Allows support for more headers in future, e.g. group information
+    return {
+        "X-Username": username
+    }  # Allows support for more headers in future, e.g. group information
 
 
 def create_async_endpoint(
@@ -82,30 +91,44 @@ def create_async_endpoint(
         async def _endpoint(
             request: Request,
             request_data: request_model = Depends(),  # type:ignore
-            username_header = Depends(extract_headers),
+            username_header=Depends(extract_headers),
         ):
             """Endpoint."""
-            return _wrap_response(await func(request=request, username_header=username_header, **request_data.kwargs()))
+            return _wrap_response(
+                await func(
+                    request=request,
+                    username_header=username_header,
+                    **request_data.kwargs(),
+                )
+            )
 
     elif issubclass(request_model, BaseModel):
 
         async def _endpoint(
             request: Request,
             request_data: request_model,  # type:ignore
-            username_header = Depends(extract_headers),
+            username_header=Depends(extract_headers),
         ):
             """Endpoint."""
-            return _wrap_response(await func(request_data, username_header=username_header, request=request))
+            return _wrap_response(
+                await func(
+                    request_data, username_header=username_header, request=request
+                )
+            )
 
     else:
 
         async def _endpoint(
             request: Request,
             request_data: Dict[str, Any],  # type:ignore
-            username_header = Depends(extract_headers),
+            username_header=Depends(extract_headers),
         ):
             """Endpoint."""
-            return _wrap_response(await func(request_data, username_header=username_header, request=request))
+            return _wrap_response(
+                await func(
+                    request_data, username_header=username_header, request=request
+                )
+            )
 
     return _endpoint
 

--- a/stac_fastapi/api/stac_fastapi/api/routes.py
+++ b/stac_fastapi/api/stac_fastapi/api/routes.py
@@ -59,6 +59,7 @@ def extract_headers(
             algorithms=["HS256"],
         )
         username = decoded_jwt.get("preferred_username")
+        print(f"Logged in as user: {username}")
     else:
         username = ""
 

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
@@ -258,7 +258,9 @@ class TransactionExtension(ApiExtension):
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["DELETE"],
-            endpoint=create_async_endpoint(self.client.delete_catalog, DeleteCatalogUri),
+            endpoint=create_async_endpoint(
+                self.client.delete_catalog, DeleteCatalogUri
+            ),
         )
 
     def register(self, app: FastAPI) -> None:

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
@@ -23,6 +23,7 @@ class PostItem(CollectionUri):
     item: Union[stac_types.Item, stac_types.ItemCollection] = attr.ib(
         default=Body(None)
     )
+    workspace: str = attr.ib(default=None)
 
 
 @attr.s
@@ -30,6 +31,8 @@ class PostCatalog(CatalogUri):
     """Create Item."""
 
     catalog: Union[stac_types.Catalog] = attr.ib(default=Body(None))
+    workspace: str = attr.ib(default=None)
+    is_public: bool = attr.ib(default=False)
 
 
 @attr.s
@@ -37,6 +40,8 @@ class PostBaseCatalog(APIRequest):
     """Create Item."""
 
     catalog: Union[stac_types.Catalog] = attr.ib(default=Body(None))
+    workspace: str = attr.ib(default=None)
+    is_public: bool = attr.ib(default=False)
 
 
 @attr.s
@@ -44,6 +49,8 @@ class PutCollection(CollectionUri):
     """Update Collection."""
 
     collection: Union[stac_types.Collection] = attr.ib(default=Body(None))
+    workspace: str = attr.ib(default=None)
+    is_public: bool = attr.ib(default=False)
 
 
 @attr.s
@@ -51,6 +58,8 @@ class PostCollection(CatalogUri):
     """Create Collection."""
 
     collection: Union[stac_types.Collection] = attr.ib(default=Body(None))
+    workspace: str = attr.ib(default=None)
+    is_public: bool = attr.ib(default=False)
 
 
 @attr.s
@@ -58,6 +67,15 @@ class PutItem(ItemUri):
     """Update Item."""
 
     item: stac_types.Item = attr.ib(default=Body(None))
+    workspace: str = attr.ib(default=None)
+    is_public: bool = attr.ib(default=False)
+
+
+@attr.s  # type:ignore
+class DeleteCatalogUri(CatalogUri):
+    """Delete catalog."""
+
+    workspace: str = attr.ib(default=None)
 
 
 @attr.s
@@ -240,7 +258,7 @@ class TransactionExtension(ApiExtension):
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["DELETE"],
-            endpoint=create_async_endpoint(self.client.delete_catalog, CatalogUri),
+            endpoint=create_async_endpoint(self.client.delete_catalog, DeleteCatalogUri),
         )
 
     def register(self, app: FastAPI) -> None:

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -85,7 +85,12 @@ class BaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     def delete_item(
-        self, item_id: str, collection_id: str, catalog_path: str, workspace: str, **kwargs
+        self,
+        item_id: str,
+        collection_id: str,
+        catalog_path: str,
+        workspace: str,
+        **kwargs,
     ) -> Optional[Union[stac_types.Item, Response]]:
         """Delete an item from a collection.
 
@@ -102,7 +107,12 @@ class BaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     def create_collection(
-        self, catalog_path: str, collection: stac_types.Collection, workspace: str, is_public: bool = False, **kwargs
+        self,
+        catalog_path: str,
+        collection: stac_types.Collection,
+        workspace: str,
+        is_public: bool = False,
+        **kwargs,
     ) -> Optional[Union[stac_types.Collection, Response]]:
         """Create a new collection.
 
@@ -118,7 +128,12 @@ class BaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     def create_catalog(
-        self, catalog: stac_types.Catalog, workspace: str, catalog_path: Optional[str], is_public: bool = False, **kwargs
+        self,
+        catalog: stac_types.Catalog,
+        workspace: str,
+        catalog_path: Optional[str],
+        is_public: bool = False,
+        **kwargs,
     ) -> Optional[Union[stac_types.Catalog, Response]]:
         """Create a new catalog.
 
@@ -150,7 +165,11 @@ class BaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     def update_collection(
-        self, collection_id: str, collection: stac_types.Collection, workspace: str, **kwargs
+        self,
+        collection_id: str,
+        collection: stac_types.Collection,
+        workspace: str,
+        **kwargs,
     ) -> Optional[Union[stac_types.Collection, Response]]:
         """Perform a complete update on an existing collection.
 
@@ -238,7 +257,12 @@ class AsyncBaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     async def delete_item(
-        self, item_id: str, collection_id: str, catalog_path: str, workspace: str, **kwargs
+        self,
+        item_id: str,
+        collection_id: str,
+        catalog_path: str,
+        workspace: str,
+        **kwargs,
     ) -> Optional[Union[stac_types.Item, Response]]:
         """Delete an item from a collection.
 
@@ -255,7 +279,11 @@ class AsyncBaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     async def create_collection(
-        self, collection: stac_types.Collection, workspace: str, is_public: bool, **kwargs
+        self,
+        collection: stac_types.Collection,
+        workspace: str,
+        is_public: bool,
+        **kwargs,
     ) -> Optional[Union[stac_types.Collection, Response]]:
         """Create a new collection.
 

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -38,8 +38,10 @@ class BaseTransactionsClient(abc.ABC):
     @abc.abstractmethod
     def create_item(
         self,
+        catalog_path: str,
         collection_id: str,
         item: Union[stac_types.Item, stac_types.ItemCollection],
+        workspace: str,
         **kwargs,
     ) -> Optional[Union[stac_types.Item, Response, None]]:
         """Create a new item.
@@ -62,6 +64,7 @@ class BaseTransactionsClient(abc.ABC):
         collection_id: str,
         item_id: str,
         item: stac_types.Item,
+        workspace: str,
         **kwargs,
     ) -> Optional[Union[stac_types.Item, Response]]:
         """Perform a complete update on an existing item.
@@ -82,7 +85,7 @@ class BaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     def delete_item(
-        self, item_id: str, collection_id: str, catalog_path: str, **kwargs
+        self, item_id: str, collection_id: str, catalog_path: str, workspace: str, **kwargs
     ) -> Optional[Union[stac_types.Item, Response]]:
         """Delete an item from a collection.
 
@@ -99,7 +102,7 @@ class BaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     def create_collection(
-        self, catalog_path: str, collection: stac_types.Collection, **kwargs
+        self, catalog_path: str, collection: stac_types.Collection, workspace: str, is_public: bool = False, **kwargs
     ) -> Optional[Union[stac_types.Collection, Response]]:
         """Create a new collection.
 
@@ -115,7 +118,7 @@ class BaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     def create_catalog(
-        self, catalog: stac_types.Catalog, catalog_path: Optional[str], **kwargs
+        self, catalog: stac_types.Catalog, workspace: str, catalog_path: Optional[str], is_public: bool = False, **kwargs
     ) -> Optional[Union[stac_types.Catalog, Response]]:
         """Create a new catalog.
 
@@ -147,7 +150,7 @@ class BaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     def update_collection(
-        self, collection_id: str, collection: stac_types.Collection, **kwargs
+        self, collection_id: str, collection: stac_types.Collection, workspace: str, **kwargs
     ) -> Optional[Union[stac_types.Collection, Response]]:
         """Perform a complete update on an existing collection.
 
@@ -167,7 +170,7 @@ class BaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     def delete_collection(
-        self, catalog_path: str, collection_id: str, **kwargs
+        self, catalog_path: str, collection_id: str, workspace: str, **kwargs
     ) -> Optional[Union[stac_types.Collection, Response]]:
         """Delete a collection.
 
@@ -189,8 +192,10 @@ class AsyncBaseTransactionsClient(abc.ABC):
     @abc.abstractmethod
     async def create_item(
         self,
+        catalog_path: str,
         collection_id: str,
         item: Union[stac_types.Item, stac_types.ItemCollection],
+        workspace: str,
         **kwargs,
     ) -> Optional[Union[stac_types.Item, Response, None]]:
         """Create a new item.
@@ -213,6 +218,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
         collection_id: str,
         item_id: str,
         item: stac_types.Item,
+        workspace: str,
         **kwargs,
     ) -> Optional[Union[stac_types.Item, Response]]:
         """Perform a complete update on an existing item.
@@ -232,7 +238,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     async def delete_item(
-        self, item_id: str, collection_id: str, catalog_path: str, **kwargs
+        self, item_id: str, collection_id: str, catalog_path: str, workspace: str, **kwargs
     ) -> Optional[Union[stac_types.Item, Response]]:
         """Delete an item from a collection.
 
@@ -249,7 +255,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     async def create_collection(
-        self, collection: stac_types.Collection, **kwargs
+        self, collection: stac_types.Collection, workspace: str, is_public: bool, **kwargs
     ) -> Optional[Union[stac_types.Collection, Response]]:
         """Create a new collection.
 
@@ -269,6 +275,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
         catalog_path: str,
         collection_id: str,
         collection: stac_types.Collection,
+        workspace: str,
         **kwargs,
     ) -> Optional[Union[stac_types.Collection, Response]]:
         """Perform a complete update on an existing collection.
@@ -289,7 +296,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     async def delete_collection(
-        self, catalog_path: str, collection_id: str, **kwargs
+        self, catalog_path: str, collection_id: str, workspace: str, **kwargs
     ) -> Optional[Union[stac_types.Collection, Response]]:
         """Delete a collection.
 


### PR DESCRIPTION
## Support Access Control for Catalogue Entries
- Add function to extract username from provided `authorization` header
  - Decode the jwt token from this head to identify the current user's `preferred_username`
  - Pass this username header to subsequent function calls
- Update routes function definitions to include `username_header` parameter
- Update core abstract functions to include `workspace` and `is_public` parameters used in elasticsearch implementation