### PR TITLE
Remove CORS middleware as this is handled by nginx instead

### DIFF
--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -15,7 +15,7 @@ from stac_pydantic.version import STAC_VERSION
 from starlette.responses import JSONResponse, Response
 
 from stac_fastapi.api.errors import DEFAULT_STATUS_CODES, add_exception_handlers
-from stac_fastapi.api.middleware import CORSMiddleware, ProxyHeaderMiddleware
+from stac_fastapi.api.middleware import ProxyHeaderMiddleware
 from stac_fastapi.api.models import (
     CatalogUri,
     CollectionUri,
@@ -133,7 +133,7 @@ class StacApi:
     response_class: Type[Response] = attr.ib(default=JSONResponse)
     middlewares: List = attr.ib(
         default=attr.Factory(
-            lambda: [BrotliMiddleware, CORSMiddleware, ProxyHeaderMiddleware]
+            lambda: [BrotliMiddleware, ProxyHeaderMiddleware]
         )
     )
     route_dependencies: List[Tuple[List[Scope], List[Depends]]] = attr.ib(default=[])


### PR DESCRIPTION
## Remove CORS Middleware from STAC-FastApi
- Removed CORS from the list of middleware used by the stac-fastapi application
- Avoids duplicate CORS headers added by nginx