### PR TITLE
Bugfix/add workspace parameter to delete commands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## EODHP
 The following changes have been made for the EODHP project
+### V0.3.9 - 2024-09-04
+Bugfix to add workspace parameter to delete_collection and delete_item endpoints
+- Ensures user has necessary access to delete the chosen collection and catalog
 ### V0.3.8 - 2024-07-30
 Access-Control Logic in Catalog
 - Adding access control to catalogs and collections added to the catalogue

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
@@ -70,6 +70,17 @@ class PutItem(ItemUri):
     workspace: str = attr.ib(default=None)
     is_public: bool = attr.ib(default=False)
 
+@attr.s  # type:ignore
+class DeleteCItemUri(ItemUri):
+    """Delete item."""
+
+    workspace: str = attr.ib(default=None)
+
+@attr.s  # type:ignore
+class DeleteCollectionUri(CollectionUri):
+    """Delete collection."""
+
+    workspace: str = attr.ib(default=None)
 
 @attr.s  # type:ignore
 class DeleteCatalogUri(CatalogUri):
@@ -146,7 +157,7 @@ class TransactionExtension(ApiExtension):
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["DELETE"],
-            endpoint=create_async_endpoint(self.client.delete_item, ItemUri),
+            endpoint=create_async_endpoint(self.client.delete_item, DeleteCItemUri),
         )
 
     def register_create_collection(self):
@@ -190,7 +201,7 @@ class TransactionExtension(ApiExtension):
             response_model_exclude_none=True,
             methods=["DELETE"],
             endpoint=create_async_endpoint(
-                self.client.delete_collection, CollectionUri
+                self.client.delete_collection, DeleteCollectionUri
             ),
         )
 


### PR DESCRIPTION
Quick update to correct workspace handling when deleting collections and items
- `workspace` required to ensure user has correct access to delete this collection or item
- This parameter is already included in requests to delete a catalog
- Noted when reviewing the delete functionality in the harvester-test