### PR TITLE
EODHP-591 manually integrate the renders stac extension into our existing stac data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,9 @@
 
 ## EODHP
 The following changes have been made for the EODHP project
-### V0.3.9 - 2024-09-04
-Bugfix to add workspace parameter to delete_collection and delete_item endpoints
+### V0.3.9 - 2024-09-06
+- Added support for the renders STAC extension at the collection level
+Bugfix to add workspace parameter to delete_collection and delete_item endpoints:
 - Ensures user has necessary access to delete the chosen collection and catalog
 ### V0.3.8 - 2024-07-30
 Access-Control Logic in Catalog

--- a/stac_fastapi/types/stac_fastapi/types/stac.py
+++ b/stac_fastapi/types/stac_fastapi/types/stac.py
@@ -60,6 +60,7 @@ class Collection(Catalog, total=False):
     links: List[Dict[str, Any]]
     renders: Dict[str, Any]
 
+
 class Item(TypedDict, total=False):
     """STAC Item."""
 

--- a/stac_fastapi/types/stac_fastapi/types/stac.py
+++ b/stac_fastapi/types/stac_fastapi/types/stac.py
@@ -58,7 +58,7 @@ class Collection(Catalog, total=False):
     summaries: Dict[str, Any]
     assets: Dict[str, Any]
     links: List[Dict[str, Any]]
-
+    renders: Dict[str, Any]
 
 class Item(TypedDict, total=False):
     """STAC Item."""


### PR DESCRIPTION
Added renders to the collection model.

Tested with creating collections with and without renders. The field is optional.