### PR TITLE
Bugfix/eodhp 582 collections need to work with stac browser

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## EODHP
 The following changes have been made for the EODHP project
+### 0.3.10 - 2024-10-01
+- Added catalog spceific endpoint for landing page
+- Updated collections search to support catalog path URLs, e.g. "/catalogs/catalog_name/collections" to search collections within that specific catalog
+- Remove unnecessary functions
+- Reorder routings to ensure correct path precedence
 ### V0.3.9 - 2024-09-06
 - Added support for the renders STAC extension at the collection level
 Bugfix to add workspace parameter to delete_collection and delete_item endpoints:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ The following changes have been made for the EODHP project
 - Updated collections search to support catalog path URLs, e.g. "/catalogs/catalog_name/collections" to search collections within that specific catalog
 - Remove unnecessary functions
 - Reorder routings to ensure correct path precedence
+- Update `create_collection` endpoint URL to be "/collection" to avoid conflict with collections search POST request
 ### V0.3.9 - 2024-09-06
 - Added support for the renders STAC extension at the collection level
 Bugfix to add workspace parameter to delete_collection and delete_item endpoints:

--- a/stac_fastapi/api/tests/benchmarks.py
+++ b/stac_fastapi/api/tests/benchmarks.py
@@ -128,11 +128,6 @@ class CoreClient(BaseCoreClient):
     ) -> stac_types.Collection:
         return collections[0]
 
-    def get_catalog_collection(
-        self, catalog_path: str, **kwargs
-    ) -> stac_types.Catalogs:
-        return collections[0]
-
     def get_catalog(self, catalog_path: str, **kwargs) -> stac_types.Catalog:
         return catalogs[0]
 

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/collection_search.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/collection_search.py
@@ -18,6 +18,8 @@ from stac_fastapi.types.extension import ApiExtension
 from stac_fastapi.types.search import (
     BaseCollectionSearchGetRequest,
     BaseCollectionSearchPostRequest,
+    CollectionSearchPostRequest,
+    CollectionSearchGetRequest
 )
 
 from .request import (
@@ -64,11 +66,18 @@ class CollectionSearchExtension(ApiExtension):
     GET = CollectionSearchExtensionGetRequest
     POST = CollectionSearchExtensionPostRequest
 
-    collections_post_request_model: Type[BaseCollectionSearchPostRequest] = attr.ib(
+    global_collections_post_request_model: Type[BaseCollectionSearchPostRequest] = attr.ib(
         default=BaseCollectionSearchPostRequest
     )
-    collections_get_request_model: Type[BaseCollectionSearchGetRequest] = attr.ib(
+    collections_post_request_model: Type[CollectionSearchPostRequest] = attr.ib(
+        default=CollectionSearchPostRequest
+    )
+
+    global_collections_get_request_model: Type[BaseCollectionSearchGetRequest] = attr.ib(
         default=BaseCollectionSearchGetRequest
+    )
+    collections_get_request_model: Type[CollectionSearchGetRequest] = attr.ib(
+        default=CollectionSearchGetRequest
     )
 
     client: Union[AsyncBaseCollectionSearchClient, BaseCollectionSearchClient] = (
@@ -107,6 +116,21 @@ class CollectionSearchExtension(ApiExtension):
             response_model_exclude_none=True,
             methods=["POST"],
             endpoint=create_async_endpoint(
+                self.client.post_all_collections, self.global_collections_post_request_model
+            ),
+        )
+
+        self.router.add_api_route(
+            name="Post Collections Catalog Specific",
+            path="/catalogs/{catalog_path:path}/collections",
+            response_model=(
+                Collections if self.settings.enable_response_models else None
+            ),
+            response_class=self.response_class,
+            response_model_exclude_unset=True,
+            response_model_exclude_none=True,
+            methods=["POST"],
+            endpoint=create_async_endpoint(
                 self.client.post_all_collections, self.collections_post_request_model
             ),
         )
@@ -114,6 +138,21 @@ class CollectionSearchExtension(ApiExtension):
         self.router.add_api_route(
             name="Get Collections",
             path="/collections",
+            response_model=(
+                Collections if self.settings.enable_response_models else None
+            ),
+            response_class=self.response_class,
+            response_model_exclude_unset=True,
+            response_model_exclude_none=True,
+            methods=["GET"],
+            endpoint=create_async_endpoint(
+                self.client.get_all_collections, self.global_collections_get_request_model
+            ),
+        )
+
+        self.router.add_api_route(
+            name="Get Collections Catalog Specific",
+            path="/catalogs/{catalog_path:path}/collections",
             response_model=(
                 Collections if self.settings.enable_response_models else None
             ),

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/request.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/request.py
@@ -3,6 +3,7 @@
 from typing import List, Optional
 
 import attr
+from fastapi import Path
 from pydantic import BaseModel, Field
 from stac_pydantic.shared import BBox
 
@@ -19,6 +20,16 @@ class CollectionSearchExtensionGetRequest(APIRequest):
     limit: Optional[int] = attr.ib(default=10)
     q: Optional[List[str]] = attr.ib(default=None, converter=str2list)
 
+@attr.s
+class CollectionSearchExtensionGetRequestExt(CollectionSearchExtensionGetRequest):
+    """Collection Search extension GET request model."""
+
+    catalog_path: str = attr.ib(
+        default=Path(
+            ..., description="Path to selected Catalog", example="cat1/cat2/cat3"
+        )
+    )
+
 
 class CollectionSearchExtensionPostRequest(BaseModel):
     """Collection Search extension POST request model."""
@@ -27,3 +38,13 @@ class CollectionSearchExtensionPostRequest(BaseModel):
     datetime: Optional[DateTimeType]
     limit: Optional[Limit] = Field(default=10)
     q: Optional[List[str]]
+
+
+class CollectionSearchExtensionPostRequestExt(CollectionSearchExtensionPostRequest):
+    """Collection Search extension POST request model."""
+
+    catalog_path: str = attr.ib(
+        default=Path(
+            ..., description="Path to selected Catalog", example="cat1/cat2/cat3"
+        )
+    )

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
@@ -164,7 +164,7 @@ class TransactionExtension(ApiExtension):
         """Register create collection endpoint (POST /catalogs/{catalog_id}/collections)."""
         self.router.add_api_route(
             name="Create Collection",
-            path="/catalogs/{catalog_path:path}/collections",
+            path="/catalogs/{catalog_path:path}/collection",
             response_model=Collection if self.settings.enable_response_models else None,
             response_class=self.response_class,
             response_model_exclude_unset=True,
@@ -231,21 +231,6 @@ class TransactionExtension(ApiExtension):
             endpoint=create_async_endpoint(self.client.create_catalog, PostBaseCatalog),
         )
 
-    def register_create_super_catalog(self):
-        """Register create catalog endpoint (POST /catalogs)."""
-        self.router.add_api_route(
-            name="Create Top-Level Catalog",
-            path="/",
-            response_model=Catalog if self.settings.enable_response_models else None,
-            response_class=self.response_class,
-            response_model_exclude_unset=True,
-            response_model_exclude_none=True,
-            methods=["POST"],
-            endpoint=create_async_endpoint(
-                self.client.create_super_catalog, stac_types.Catalog
-            ),
-        )
-
     def register_update_catalog(self):
         """Register update collection endpoint (PUT /collections/{collection_id})."""
         self.router.add_api_route(
@@ -290,7 +275,6 @@ class TransactionExtension(ApiExtension):
         self.register_create_collection()
         self.register_create_catalog()
         self.register_create_base_catalog()
-        # self.register_create_super_catalog()
         self.register_update_collection()
         self.register_update_catalog()
         self.register_delete_collection()

--- a/stac_fastapi/extensions/tests/test_transaction.py
+++ b/stac_fastapi/extensions/tests/test_transaction.py
@@ -21,9 +21,6 @@ class DummyCoreClient(BaseCoreClient):
     def get_collection(self, *args, **kwargs):
         raise NotImplementedError
 
-    def get_catalog_collections(self, *args, **kwargs):
-        raise NotImplementedError
-
     def get_item(self, *args, **kwargs):
         raise NotImplementedError
 

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -674,22 +674,6 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
         ...
 
     @abc.abstractmethod
-    def get_catalog_collections(
-        self, catalog_path: str, **kwargs
-    ) -> stac_types.Collections:
-        """Get collections by catalog id.
-
-        Called with `GET /catalogs/{catalog_id}/collections`.
-
-        Args:
-            catalog_id: Id of the catalog.
-
-        Returns:
-            Collections.
-        """
-        ...
-
-    @abc.abstractmethod
     def item_collection(
         self,
         collection_id: str,

--- a/stac_fastapi/types/stac_fastapi/types/search.py
+++ b/stac_fastapi/types/stac_fastapi/types/search.py
@@ -355,8 +355,17 @@ class BaseCollectionSearchGetRequest(APIRequest):
     limit: Optional[int] = attr.ib(default=10)
     q: Optional[List[str]] = attr.ib(default=None, converter=str2list)
 
+@attr.s
+class CollectionSearchGetRequest(BaseCollectionSearchGetRequest):
+    """Base arguments for Collection Search GET Request with Catalog path"""
+    catalog_path: str = attr.ib(
+        default=Path(
+            ..., description="Path to selected Catalog", example="cat1/cat2/cat3"
+        )
+    )
 
-class BaseCollectionSearchPostRequest(BaseModel):
+
+class BaseCollectionSearchPostRequest(Search):
     """Search model.
     Replace base model in STAC-pydantic as it includes additional fields, not in the core
     model.
@@ -404,6 +413,15 @@ class BaseCollectionSearchPostRequest(BaseModel):
         if type(v) == str:
             v = str_to_interval(v)
         return v
+
+@attr.s
+class CollectionSearchPostRequest(APIRequest):
+    """Search model.
+    Replace base model in STAC-pydantic as it includes additional fields, not in the core
+    model. Also includes Catalog path.
+    """
+    catalog_path: str = attr.ib(default=Path(..., description="Catalog Path"))
+    search_request: BaseCollectionSearchPostRequest = attr.ib(default=None)
 
 
 @attr.s


### PR DESCRIPTION
## Updated to better support STAC Browser
- Added catalog spceific endpoint for landing page
- Updated collections search to support catalog path URLs, e.g. `/catalogs/catalog_name/collections` to search collections within that specific catalog
  - This endpoint will return all collections in the given catalog, including in nested catalogs
  - Additional types required to include `catalog_path`
  - Removing `catalog_collections` function as no longer needed
- Remove unnecessary functions
- Reorder routings to ensure correct path precedence
- Update `create_collection` endpoint URL to be "/collection" to avoid conflict with collections search POST request. This is referenced in the parent repository [here ](https://github.com/stac-utils/stac-fastapi/issues/749 )with no current fix.
- This addresses the "The API Collections could not be loaded" error seen when using STAC Browser