### PR TITLE
Feature/eodhp 803 user can create metadata access policy

### DIFF
--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -131,9 +131,7 @@ class StacApi:
     pagination_extension = attr.ib(default=TokenPaginationExtension)
     response_class: Type[Response] = attr.ib(default=JSONResponse)
     middlewares: List = attr.ib(
-        default=attr.Factory(
-            lambda: [BrotliMiddleware, ProxyHeaderMiddleware]
-        )
+        default=attr.Factory(lambda: [BrotliMiddleware, ProxyHeaderMiddleware])
     )
     route_dependencies: List[Tuple[List[Scope], List[Depends]]] = attr.ib(default=[])
 
@@ -325,31 +323,6 @@ class StacApi:
             ),
         )
 
-    def register_get_collections(self):
-        """Register get collections endpoint (GET /collections).
-
-        Returns:
-            None
-        """
-        collection_search_ext = self.get_extension(CollectionSearchExtension)
-        if not collection_search_ext:
-            self.router.add_api_route(
-                name="Get Collections",
-                path="/collections",
-                response_model=(
-                    (Collections if not collection_search_ext else None)
-                    if self.settings.enable_response_models
-                    else None
-                ),
-                response_class=self.response_class,
-                response_model_exclude_unset=True,
-                response_model_exclude_none=True,
-                methods=["GET"],
-                endpoint=create_async_endpoint(
-                    self.client.all_collections, EmptyRequest
-                ),
-            )
-
     def register_get_catalogs(self):
         """Register get catalogs endpoint (GET /catalogs).
 
@@ -383,7 +356,6 @@ class StacApi:
             methods=["GET"],
             endpoint=create_async_endpoint(self.client.all_catalogs, EmptyRequest),
         )
-
 
     def register_get_collection(self):
         """Register get collection endpoint (GET /catalogs/{catalog_id}/collection/{collection_id}).
@@ -467,20 +439,19 @@ class StacApi:
         Returns:
             None
         """
-        self.register_root_landing_page() # "/"
-        self.register_landing_page() # "/catalogs/{catalog_path}/"
-        self.register_conformance_classes() # "/conformance"
-        self.register_post_global_search() # "/search"
-        self.register_get_global_search() # "/search"
-        self.register_get_all_catalogs() # "/catalogs"
-        self.register_post_search() # "/catalogs/{catalog_path}/search"
-        self.register_get_search() # "/catalogs/{catalog_path}/search"
-        self.register_get_item() # "/catalogs/{catalog_path}/collections/{collection_id}/items/{item_id}"
-        self.register_get_item_collection() # "/catalogs/{catalog_path}/collections/{collection_id}/items"
-        self.register_get_collection() # "/catalogs/{catalog_path}/collections/{collection_id}"
-        self.register_get_catalogs() # "/catalogs/{catalog_path}/catalogs"
-        self.register_get_catalog() # "/catalogs/{catalog_path}"       
-        
+        self.register_root_landing_page()  # "/"
+        self.register_landing_page()  # "/catalogs/{catalog_path}/"
+        self.register_conformance_classes()  # "/conformance"
+        self.register_post_global_search()  # "/search"
+        self.register_get_global_search()  # "/search"
+        self.register_get_all_catalogs()  # "/catalogs"
+        self.register_post_search()  # "/catalogs/{catalog_path}/search"
+        self.register_get_search()  # "/catalogs/{catalog_path}/search"
+        self.register_get_item()  # "/catalogs/{catalog_path}/collections/{collection_id}/items/{item_id}"
+        self.register_get_item_collection()  # "/catalogs/{catalog_path}/collections/{collection_id}/items"
+        self.register_get_collection()  # "/catalogs/{catalog_path}/collections/{collection_id}"
+        self.register_get_catalogs()  # "/catalogs/{catalog_path}/catalogs"
+        self.register_get_catalog()  # "/catalogs/{catalog_path}"
 
     def customize_openapi(self) -> Optional[Dict[str, Any]]:
         """Customize openapi schema."""
@@ -558,13 +529,12 @@ class StacApi:
 
         # Register core STAC endpoints
         self.register_core()
-        self.app.include_router(self.router)
+        self.app.include_router(self.router, tags=["Search/Retrieve Endpoints"])
 
         # register extensions
         for ext in self.extensions:
             ext.register(self.app)
 
-        
         # add health check
         self.add_health_check()
 

--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -545,7 +545,7 @@ class StacApi:
         router_prefix = self.router.prefix
         self.app.state.router_prefix = router_prefix if router_prefix else ""
 
-        # register collection search extensions
+        # register collection search extensions first to ensure precendence over other endpoints
         for ext in self.extensions:
             if isinstance(ext, CollectionSearchExtension):
                 ext.register(self.app)
@@ -556,7 +556,8 @@ class StacApi:
 
         # register extensions
         for ext in self.extensions:
-            ext.register(self.app)
+            if not isinstance(ext, CollectionSearchExtension):
+                ext.register(self.app)
 
         # add health check
         self.add_health_check()

--- a/stac_fastapi/api/stac_fastapi/api/models.py
+++ b/stac_fastapi/api/stac_fastapi/api/models.py
@@ -237,7 +237,8 @@ class CatalogUri(APIRequest):
 
     catalog_path: str = attr.ib(
         default=Path(
-            ..., description="Path to selected Catalog", example="cat1/cat2/cat3"
+            ..., description="Path to selected Catalog", example="catalogs/catalog_1/catalogs/catalog_2",
+            # regex=r"^catalogs/[^/]+(/catalogs/[^/]+)*$"
         )
     )
 
@@ -254,7 +255,6 @@ class ItemUri(CollectionUri):
     """Delete item."""
 
     item_id: str = attr.ib(default=Path(..., description="Item ID"))
-
 
 @attr.s
 class EmptyRequest(APIRequest):

--- a/stac_fastapi/api/stac_fastapi/api/models.py
+++ b/stac_fastapi/api/stac_fastapi/api/models.py
@@ -239,7 +239,7 @@ class CatalogUri(APIRequest):
         default=Path(
             ...,
             description="Path to selected Catalog",
-            example="catalogs/catalog_1/catalogs/catalog_2",
+            example="catalog_1/catalog_2",
             # regex=r"^catalogs/[^/]+(/catalogs/[^/]+)*$"
         )
     )

--- a/stac_fastapi/api/stac_fastapi/api/models.py
+++ b/stac_fastapi/api/stac_fastapi/api/models.py
@@ -237,7 +237,9 @@ class CatalogUri(APIRequest):
 
     catalog_path: str = attr.ib(
         default=Path(
-            ..., description="Path to selected Catalog", example="catalogs/catalog_1/catalogs/catalog_2",
+            ...,
+            description="Path to selected Catalog",
+            example="catalogs/catalog_1/catalogs/catalog_2",
             # regex=r"^catalogs/[^/]+(/catalogs/[^/]+)*$"
         )
     )
@@ -255,6 +257,7 @@ class ItemUri(CollectionUri):
     """Delete item."""
 
     item_id: str = attr.ib(default=Path(..., description="Item ID"))
+
 
 @attr.s
 class EmptyRequest(APIRequest):

--- a/stac_fastapi/api/stac_fastapi/api/routes.py
+++ b/stac_fastapi/api/stac_fastapi/api/routes.py
@@ -22,6 +22,7 @@ from stac_fastapi.api.models import APIRequest
 
 logger = logging.getLogger(__name__)
 
+
 def _wrap_response(resp: Any) -> Any:
     if resp is not None:
         return resp

--- a/stac_fastapi/api/stac_fastapi/api/routes.py
+++ b/stac_fastapi/api/stac_fastapi/api/routes.py
@@ -2,6 +2,7 @@
 
 import functools
 import inspect
+import logging
 import warnings
 from typing import Any, Callable, Dict, List, Optional, Type, TypedDict, Union
 
@@ -18,6 +19,8 @@ from starlette.status import HTTP_204_NO_CONTENT
 
 from stac_fastapi.api.models import APIRequest
 
+
+logger = logging.getLogger(__name__)
 
 def _wrap_response(resp: Any) -> Any:
     if resp is not None:
@@ -59,9 +62,10 @@ def extract_headers(
             algorithms=["HS256"],
         )
         username = decoded_jwt.get("preferred_username")
-        print(f"Logged in as user: {username}")
+        logger.info(f"Logged in as user: {username}")
     else:
         username = ""
+        logger.info(f"Not logged in as any user")
 
     return {
         "X-Username": username

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/collection_search.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/collection_search.py
@@ -19,7 +19,7 @@ from stac_fastapi.types.search import (
     BaseCollectionSearchGetRequest,
     BaseCollectionSearchPostRequest,
     CollectionSearchPostRequest,
-    CollectionSearchGetRequest
+    CollectionSearchGetRequest,
 )
 
 from .request import (
@@ -66,15 +66,15 @@ class CollectionSearchExtension(ApiExtension):
     GET = CollectionSearchExtensionGetRequest
     POST = CollectionSearchExtensionPostRequest
 
-    global_collections_post_request_model: Type[BaseCollectionSearchPostRequest] = attr.ib(
-        default=BaseCollectionSearchPostRequest
+    global_collections_post_request_model: Type[BaseCollectionSearchPostRequest] = (
+        attr.ib(default=BaseCollectionSearchPostRequest)
     )
     collections_post_request_model: Type[CollectionSearchPostRequest] = attr.ib(
         default=CollectionSearchPostRequest
     )
 
-    global_collections_get_request_model: Type[BaseCollectionSearchGetRequest] = attr.ib(
-        default=BaseCollectionSearchGetRequest
+    global_collections_get_request_model: Type[BaseCollectionSearchGetRequest] = (
+        attr.ib(default=BaseCollectionSearchGetRequest)
     )
     collections_get_request_model: Type[CollectionSearchGetRequest] = attr.ib(
         default=CollectionSearchGetRequest
@@ -116,8 +116,10 @@ class CollectionSearchExtension(ApiExtension):
             response_model_exclude_none=True,
             methods=["POST"],
             endpoint=create_async_endpoint(
-                self.client.post_all_collections, self.global_collections_post_request_model
+                self.client.post_all_collections,
+                self.global_collections_post_request_model,
             ),
+            operation_id="post_collections",
         )
 
         self.router.add_api_route(
@@ -133,6 +135,7 @@ class CollectionSearchExtension(ApiExtension):
             endpoint=create_async_endpoint(
                 self.client.post_all_collections, self.collections_post_request_model
             ),
+            operation_id="post_collections_catalog_specific",
         )
 
         self.router.add_api_route(
@@ -146,8 +149,10 @@ class CollectionSearchExtension(ApiExtension):
             response_model_exclude_none=True,
             methods=["GET"],
             endpoint=create_async_endpoint(
-                self.client.get_all_collections, self.global_collections_get_request_model
+                self.client.get_all_collections,
+                self.global_collections_get_request_model,
             ),
+            operation_id="get_collections",
         )
 
         self.router.add_api_route(
@@ -163,6 +168,7 @@ class CollectionSearchExtension(ApiExtension):
             endpoint=create_async_endpoint(
                 self.client.get_all_collections, self.collections_get_request_model
             ),
+            operation_id="get_collections_catalog_specific",
         )
 
-        app.include_router(self.router)
+        app.include_router(self.router, tags=["Search/Retrieve Endpoints"])

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/request.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/request.py
@@ -20,6 +20,7 @@ class CollectionSearchExtensionGetRequest(APIRequest):
     limit: Optional[int] = attr.ib(default=10)
     q: Optional[List[str]] = attr.ib(default=None, converter=str2list)
 
+
 @attr.s
 class CollectionSearchExtensionGetRequestExt(CollectionSearchExtensionGetRequest):
     """Collection Search extension GET request model."""

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
@@ -32,7 +32,13 @@ class PostCatalog(CatalogUri):
 
     catalog: Union[stac_types.Catalog] = attr.ib(default=Body(None))
     workspace: str = attr.ib(default=None)
-    is_public: bool = attr.ib(default=False)
+
+@attr.s
+class PutCatalog(CatalogUri):
+    """Create Catalog."""
+
+    catalog: Union[stac_types.Catalog] = attr.ib(default=Body(None))
+    workspace: str = attr.ib(default=None)
 
 
 @attr.s
@@ -40,8 +46,7 @@ class UpdateCatalogAccess(CatalogUri):
     """Create Catalog."""
 
     workspace: str = attr.ib(default=None)
-    is_public: bool = attr.ib(default=False)
-    access_list: List[str] = attr.ib(default=[])
+    access_policy: Union[stac_types.AccessPolicy] = attr.ib(default=Body(None))
 
 
 @attr.s
@@ -50,7 +55,6 @@ class PostBaseCatalog(APIRequest):
 
     workspace: str = attr.ib(default=None)
     catalog: Union[stac_types.Catalog] = attr.ib(default=Body(None))
-    is_public: bool = attr.ib(default=False)
 
 
 @attr.s
@@ -58,12 +62,11 @@ class UpdateCollectionAccess(CollectionUri):
     """Update Collection."""
 
     workspace: str = attr.ib(default=None)
-    is_public: bool = attr.ib(default=False)
-    access_list: List[str] = attr.ib(default=[])
+    access_policy: Union[stac_types.AccessPolicy] = attr.ib(default=Body(None))
 
 
 @attr.s
-class PutCollection(CatalogUri):
+class PutCollection(CollectionUri):
     """Update Collection."""
 
     collection: Union[stac_types.Collection] = attr.ib(default=Body(None))
@@ -76,7 +79,6 @@ class PostCollection(CatalogUri):
 
     collection: Union[stac_types.Collection] = attr.ib(default=Body(None))
     workspace: str = attr.ib(default=None)
-    is_public: bool = attr.ib(default=False)
 
 
 @attr.s
@@ -260,7 +262,7 @@ class TransactionExtension(ApiExtension):
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["PUT"],
-            endpoint=create_async_endpoint(self.client.update_catalog, PostCatalog),
+            endpoint=create_async_endpoint(self.client.update_catalog, PutCatalog),
         )
 
     def register_delete_catalog(self):
@@ -282,7 +284,7 @@ class TransactionExtension(ApiExtension):
         """Register update collection endpoint (PUT /catalogs/{catalog_path})."""
         self.router.add_api_route(
             name="Update Catalog Access Control",
-            path="/catalogs/{catalog_path:path}/access",
+            path="/catalogs/{catalog_path:path}/access-policy",
             response_model=Catalog if self.settings.enable_response_models else None,
             response_class=self.response_class,
             response_model_exclude_unset=True,
@@ -297,7 +299,7 @@ class TransactionExtension(ApiExtension):
         """Register update collection endpoint (PUT /catalogs/{catalog_path}/collections/{collection_id})."""
         self.router.add_api_route(
             name="Update Collection Access Control",
-            path="/catalogs/{catalog_path:path}/collections/{collection_id}/access",
+            path="/catalogs/{catalog_path:path}/collections/{collection_id}/access-policy",
             response_model=Collection if self.settings.enable_response_models else None,
             response_class=self.response_class,
             response_model_exclude_unset=True,

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
@@ -34,6 +34,7 @@ class PostCatalog(CatalogUri):
     workspace: str = attr.ib(default=None)
     is_public: bool = attr.ib(default=False)
 
+
 @attr.s
 class PutCatalogStripped(CatalogUri):
     """Create Catalog."""
@@ -46,6 +47,7 @@ class PutCatalogStripped(CatalogUri):
 @attr.s
 class PostBaseCatalog(APIRequest):
     """Create Catalog."""
+
     workspace: str = attr.ib(default=None)
     catalog: Union[stac_types.Catalog] = attr.ib(default=Body(None))
     is_public: bool = attr.ib(default=False)
@@ -74,6 +76,7 @@ class PostCollection(CatalogUri):
     collection: Union[stac_types.Collection] = attr.ib(default=Body(None))
     workspace: str = attr.ib(default=None)
     is_public: bool = attr.ib(default=False)
+
 
 @attr.s
 class PutItem(ItemUri):
@@ -284,7 +287,9 @@ class TransactionExtension(ApiExtension):
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["PUT"],
-            endpoint=create_async_endpoint(self.client.update_catalog_access_control, PutCatalogStripped),
+            endpoint=create_async_endpoint(
+                self.client.update_catalog_access_control, PutCatalogStripped
+            ),
         )
 
     def register_update_collection_access(self):
@@ -318,7 +323,7 @@ class TransactionExtension(ApiExtension):
         self.register_create_collection()
         self.register_create_catalog()
         self.register_create_base_catalog()
-        
+
         self.register_delete_collection()
         self.register_delete_catalog()
         self.register_update_collection_access()

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
@@ -36,7 +36,7 @@ class PostCatalog(CatalogUri):
 
 
 @attr.s
-class PutCatalogStripped(CatalogUri):
+class UpdateCatalogAccess(CatalogUri):
     """Create Catalog."""
 
     workspace: str = attr.ib(default=None)
@@ -54,7 +54,7 @@ class PostBaseCatalog(APIRequest):
 
 
 @attr.s
-class PutCollectionStripped(CollectionUri):
+class UpdateCollectionAccess(CollectionUri):
     """Update Collection."""
 
     workspace: str = attr.ib(default=None)
@@ -63,10 +63,11 @@ class PutCollectionStripped(CollectionUri):
 
 
 @attr.s
-class PutCollection(PutCollectionStripped):
+class PutCollection(CatalogUri):
     """Update Collection."""
 
     collection: Union[stac_types.Collection] = attr.ib(default=Body(None))
+    workspace: str = attr.ib(default=None)
 
 
 @attr.s
@@ -288,7 +289,7 @@ class TransactionExtension(ApiExtension):
             response_model_exclude_none=True,
             methods=["PUT"],
             endpoint=create_async_endpoint(
-                self.client.update_catalog_access_control, PutCatalogStripped
+                self.client.update_catalog_access_control, UpdateCatalogAccess
             ),
         )
 
@@ -303,7 +304,7 @@ class TransactionExtension(ApiExtension):
             response_model_exclude_none=True,
             methods=["PUT"],
             endpoint=create_async_endpoint(
-                self.client.update_collection_access_control, PutCollectionStripped
+                self.client.update_collection_access_control, UpdateCollectionAccess
             ),
         )
 

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -111,7 +111,6 @@ class BaseTransactionsClient(abc.ABC):
         catalog_path: str,
         collection: stac_types.Collection,
         workspace: str,
-        is_public: bool = False,
         **kwargs,
     ) -> Optional[Union[stac_types.Collection, Response]]:
         """Create a new collection.
@@ -132,7 +131,6 @@ class BaseTransactionsClient(abc.ABC):
         catalog: stac_types.Catalog,
         workspace: str,
         catalog_path: Optional[str],
-        is_public: bool = False,
         **kwargs,
     ) -> Optional[Union[stac_types.Catalog, Response]]:
         """Create a new catalog.
@@ -200,6 +198,52 @@ class BaseTransactionsClient(abc.ABC):
 
         Returns:
             The deleted collection.
+        """
+        ...
+
+    @abc.abstractmethod
+    async def update_catalog_access_control(
+        self,
+        workspace: str,
+        access_policy: stac_types.AccessPolicy,
+        catalog_path: str,
+        **kwargs,
+    ):
+        """Update the access policy for a catalog.
+
+        Called with `PUT /catalogs/{catalog_path}/access-policy`
+
+        Args:
+            workspace: the user's workspace
+            access_policy: dictionary defining access policy for the collection
+            catalog_path: path to the catalog
+
+        Returns:
+            N/A
+        """
+        ...
+
+    @abc.abstractmethod
+    async def update_collection_access_control(
+        self,
+        workspace: str,
+        collection_id: str,
+        access_policy: stac_types.AccessPolicy,
+        catalog_path: Optional[str] = None,
+        **kwargs,
+    ):
+        """Update the access policy for a collection.
+
+        Called with `PUT /catalogs/{catalog_path}/collections/{collection_id}/access-policy`
+
+        Args:
+            workspace: the user's workspace
+            catalog_path: path to the catalog
+            access_policy: dictionary defining access policy for the collection
+            collection_id: id of the collection.
+
+        Returns:
+            N/A
         """
         ...
 
@@ -282,7 +326,6 @@ class AsyncBaseTransactionsClient(abc.ABC):
         self,
         collection: stac_types.Collection,
         workspace: str,
-        is_public: bool,
         **kwargs,
     ) -> Optional[Union[stac_types.Collection, Response]]:
         """Create a new collection.
@@ -335,6 +378,116 @@ class AsyncBaseTransactionsClient(abc.ABC):
 
         Returns:
             The deleted collection.
+        """
+        ...
+
+    @abc.abstractmethod
+    async def create_catalog(
+        self,
+        catalog: stac_types.Catalog,
+        workspace: str,
+        catalog_path: Optional[str] = None,
+        **kwargs,
+    ) -> stac_types.Catalog:
+        """Create a new catalog in the database.
+
+        Args:
+            catalog (stac_types.Catalog): The catalog to be created.
+            workspace (str): The workspace being used to create the catalog.
+            catalog_path (Optional[str]): The path to the catalog to be created.
+            is_public (bool): Whether the catalog is public or not.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            stac_types.Catalog: The created catalog object.
+
+        """
+        ...
+
+    @abc.abstractmethod
+    async def update_catalog(
+        self, catalog_path: str, catalog: stac_types.Catalog, workspace: str, **kwargs
+    ) -> stac_types.Catalog:
+        """
+        Update a catalog.
+
+        This method updates an existing catalog in the database.
+
+        Args:
+            catalog_path: Path to the catalog.
+            catalog: The updated catalog.
+            workspace: The user's workspace.
+            kwargs: Additional keyword arguments.
+
+        Returns:
+            A STAC catalog that has been updated in the database.
+
+        """
+        ...
+
+    @abc.abstractmethod
+    async def delete_catalog(
+        self, catalog_path: str, workspace: str, **kwargs
+    ) -> Optional[stac_types.Catalog]:
+        """
+        Delete a catalog.
+
+        This method deletes an existing catalog in the database.
+
+        Args:
+            catalog_path: Path to the catalog.
+            workspace: The user's workspace.
+            kwargs: Additional keyword arguments.
+
+        Returns:
+            None.
+
+        """
+        ...
+
+    @abc.abstractmethod
+    async def update_catalog_access_control(
+        self,
+        workspace: str,
+        access_policy: stac_types.AccessPolicy,
+        catalog_path: str,
+        **kwargs,
+    ):
+        """Update the access policy for a catalog.
+
+        Called with `PUT /catalogs/{catalog_path}/access-policy`
+
+        Args:
+            workspace: the user's workspace
+            access_policy: dictionary defining access policy for the collection
+            catalog_path: path to the catalog
+
+        Returns:
+            N/A
+        """
+        ...
+
+    @abc.abstractmethod
+    async def update_collection_access_control(
+        self,
+        workspace: str,
+        collection_id: str,
+        access_policy: stac_types.AccessPolicy,
+        catalog_path: Optional[str] = None,
+        **kwargs,
+    ):
+        """Update the access policy for a collection.
+
+        Called with `PUT /catalogs/{catalog_path}/collections/{collection_id}/access-policy`
+
+        Args:
+            workspace: the user's workspace
+            catalog_path: path to the catalog
+            access_policy: dictionary defining access policy for the collection
+            collection_id: id of the collection.
+
+        Returns:
+            N/A
         """
         ...
 

--- a/stac_fastapi/types/stac_fastapi/types/search.py
+++ b/stac_fastapi/types/stac_fastapi/types/search.py
@@ -355,9 +355,11 @@ class BaseCollectionSearchGetRequest(APIRequest):
     limit: Optional[int] = attr.ib(default=10)
     q: Optional[List[str]] = attr.ib(default=None, converter=str2list)
 
+
 @attr.s
 class CollectionSearchGetRequest(BaseCollectionSearchGetRequest):
     """Base arguments for Collection Search GET Request with Catalog path"""
+
     catalog_path: str = attr.ib(
         default=Path(
             ..., description="Path to selected Catalog", example="cat1/cat2/cat3"
@@ -414,12 +416,14 @@ class BaseCollectionSearchPostRequest(Search):
             v = str_to_interval(v)
         return v
 
+
 @attr.s
 class CollectionSearchPostRequest(APIRequest):
     """Search model.
     Replace base model in STAC-pydantic as it includes additional fields, not in the core
     model. Also includes Catalog path.
     """
+
     catalog_path: str = attr.ib(default=Path(..., description="Catalog Path"))
     search_request: BaseCollectionSearchPostRequest = attr.ib(default=None)
 

--- a/stac_fastapi/types/stac_fastapi/types/stac.py
+++ b/stac_fastapi/types/stac_fastapi/types/stac.py
@@ -29,6 +29,11 @@ class LandingPage(TypedDict, total=False):
     conformsTo: List[str]
     links: List[Dict[str, Any]]
 
+class AccessPolicy(TypedDict, total=False):
+    """Metadata Access Policy."""
+
+    public: bool
+    acl: List[str]
 
 class Conformance(TypedDict):
     """STAC Conformance Classes."""


### PR DESCRIPTION
## Support Metadata Access Policy Updates
- Add new endpoints for updating access control for catalogs and collections
- Define classes for new access_list inputs
- Remove duplicate collections search definition
- Add `operation_ids` to avoid endpoint conflicts